### PR TITLE
Issue#6

### DIFF
--- a/InvokePlaster.ps1
+++ b/InvokePlaster.ps1
@@ -35,9 +35,9 @@ function Invoke-Plaster {
         $paramDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 
         try {
-            if (!($TemplatePath -and
-                ($manifestPath = Join-Path $TemplatePath 'plasterManifest.xml') -and
-                (Test-path $manifestPath))
+            if ((!$TemplatePath -or
+                !($manifestPath = Join-Path $TemplatePath 'plasterManifest.xml') -or
+                !(Test-path $manifestPath))
             ) {
                 return
             }

--- a/InvokePlaster.ps1
+++ b/InvokePlaster.ps1
@@ -35,6 +35,12 @@ function Invoke-Plaster {
         $paramDictionary = New-Object System.Management.Automation.RuntimeDefinedParameterDictionary
 
         try {
+            if (!($TemplatePath -and
+                ($manifestPath = Join-Path $TemplatePath 'plasterManifest.xml') -and
+                (Test-path $manifestPath))
+            ) {
+                return
+            }
             $manifestPath = Join-Path $TemplatePath 'plasterManifest.xml'
             $manifest = [xml](Get-Content $manifestPath -ErrorAction SilentlyContinue)
 


### PR DESCRIPTION
To fix #6 where it errors on the DynamicParam, I've encapsulated the DynamicParam $ManifestPath work in a if(){} block that will check whether the variable is set, and the file exists.

It's not really pretty, but more accurate (and avoid unnecessary Errors).
Feedback welcome ;)