### PR TITLE
Change the modify directive to use element form.

### DIFF
--- a/Examples/NewModuleTemplate/plasterManifest.xml
+++ b/Examples/NewModuleTemplate/plasterManifest.xml
@@ -90,11 +90,15 @@
         <file source='tasks.json'
               destination='.vscode\tasks.json'
               condition="$PLASTER_PARAM_Editor -eq 'VSCode'"/>
-        <modify path='.vscode\tasks.json'
-                encoding='utf8'
-                condition="$PLASTER_PARAM_Editor -eq 'VSCode' -and $PLASTER_PARAM_Options -contains 'Pester' -and $PLASTER_FileContent -notmatch 'taskName&quot;:\s*&quot;Test&quot;'">
-            <replacement pattern='(?si)(?&lt;="tasks":\s*\[)(\s*)(?=\{)'>
-            <![CDATA[$1{
+        <modify path='.vscode\tasks.json' encoding='utf8'
+                condition="$PLASTER_PARAM_Editor -eq 'VSCode'">
+            <replace condition="$PLASTER_FileContent -notmatch '// Author:'">
+                <original>(?s)^(.*)</original>
+                <substitute expand='true'>``$1`r`n// Author: $PLASTER_PARAM_FullName</substitute>
+            </replace>
+            <replace condition="$PLASTER_PARAM_Options -contains 'Pester' -and $PLASTER_FileContent -notmatch 'taskName&quot;:\s*&quot;Test&quot;'">
+                <original><![CDATA[(?si)(?<="tasks":\s*\[)(\s*)(?=\{)]]></original>
+                <substitute><![CDATA[$1{
             "taskName": "Test",
             "suppressTaskName": true,
             "isTestCommand": true,
@@ -121,8 +125,22 @@
                     ]
                 }
             ]
-        },$1]]>
-            </replacement>
+        },$1]]></substitute>
+            </replace>
+
+            <replace condition="$PLASTER_PARAM_Options -contains 'PSake' -and $PLASTER_FileContent -notmatch 'taskName&quot;:\s*&quot;Build&quot;'">
+                <original><![CDATA[(?si)(?<="tasks":\s*\[)(\s*)(?=\{)]]></original>
+                <substitute><![CDATA[$1{
+            "taskName": "Build",
+            "suppressTaskName": true,
+            "isBuildCommand": true,
+            "showOutput": "always",
+            "args": [
+                "Write-Host 'Invoking PSake...'; Invoke-PSake build.ps1 -taskList Build;",
+                "Invoke-Command { Write-Host 'Completed Build task in task runner.' }"
+            ]
+        },$1]]></substitute>
+            </replace>
         </modify>
     </content>
 </plasterManifest>

--- a/Examples/NewModuleTemplate/tasks.json
+++ b/Examples/NewModuleTemplate/tasks.json
@@ -1,26 +1,3 @@
-// A task runner that invokes Pester to run all Pester tests under the
-// current workspace folder.
-
-// NOTE: This Test task runner requires an updated version of Pester (>=3.4.0)
-// in order for the problemMatcher to find failed test information (message, line, file).
-// If you don't have that version, you can update Pester from the PowerShell Gallery
-// with this command:
-//
-// PS C:\> Update-Module Pester
-//
-// If that gives an error like:
-// "Module 'Pester' was not installed by using Install-Module, so it cannot be updated."
-// then execute:
-//
-// PS C:\> Install-Module Pester -Scope CurrentUser -Force
-//
-
-// NOTE: The Clean, Build and Publish tasks require PSake. PSake can be installed
-// from the PowerShell Gallery with this command:
-//
-// PS C:\> Install-Module PSake -Scope CurrentUser -Force
-//
-
 // Available variables which can be used inside of strings.
 // ${workspaceRoot}: the root folder of the team
 // ${file}: the current opened file
@@ -53,16 +30,6 @@
             "args": [
                 "Write-Host 'Invoking PSake...'; Invoke-PSake build.ps1 -taskList Clean;",
                 "Invoke-Command { Write-Host 'Completed Clean task in task runner.' }"
-            ]
-        },
-        {
-            "taskName": "Build",
-            "suppressTaskName": true,
-            "isBuildCommand": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking PSake...'; Invoke-PSake build.ps1 -taskList Build;",
-                "Invoke-Command { Write-Host 'Completed Build task in task runner.' }"
             ]
         },
         {


### PR DESCRIPTION
This allows use of CDATA sections to make entering regexes a bit easier.   Also added expand attribute as a way to tell Plaster to expand the string or not.  This would be like selecting between single quotes (not expanded) which is the default or double quotes (expanded).

There is an issue with ExpandString that needs to be resolved.  Right now if you expand the substitute string and want to use regex $1 you have to specify it as ``$1.  It seems to me it should be only `$1.