### PR TITLE
Could not resolve source if working dir is outside of template Path

### DIFF
--- a/InvokePlaster.ps1
+++ b/InvokePlaster.ps1
@@ -462,7 +462,7 @@ __________.__                   __
 
                 $leaf = Split-Path $parent -Leaf
                 if ($leaf -eq '**') {
-                    $parent = Split-Path $srcPath -Parent
+                    $parent = Split-Path $parent -Parent
                     $gciParams['LiteralPath'] = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($parent)
                     $gciParams['Recurse'] = $true
                 }

--- a/InvokePlaster.ps1
+++ b/InvokePlaster.ps1
@@ -446,9 +446,10 @@ __________.__                   __
 
             # Prepare parameter values for call to Get-ChildItem to get list of files based on wildcard spec
             $gciParams = @{}
-            $parent = Split-Path $srcRelPath -Parent
-            $leaf = Split-Path $srcRelPath -Leaf
-            $gciParams['LiteralPath'] = $PSCmdlet.GetUnresolvedProviderPathFromPSPath((Join-Path $TemplatePath $parent))
+            $srcPath = Join-Path $TemplatePath $parent
+            $parent = Split-Path $srcPath -Parent
+            $leaf = Split-Path $srcPath -Leaf
+            $gciParams['LiteralPath'] = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($parent)
             $gciParams['File'] = $true
 
             if ($leaf -eq '**') {
@@ -461,8 +462,8 @@ __________.__                   __
 
                 $leaf = Split-Path $parent -Leaf
                 if ($leaf -eq '**') {
-                    $parent = Split-Path $parent -Parent
-                    $gciParams['LiteralPath'] = $PSCmdlet.GetUnresolvedProviderPathFromPSPath((Join-Path $TemplatePath $parent))
+                    $parent = Split-Path $srcPath -Parent
+                    $gciParams['LiteralPath'] = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($parent)
                     $gciParams['Recurse'] = $true
                 }
             }

--- a/InvokePlaster.ps1
+++ b/InvokePlaster.ps1
@@ -448,7 +448,7 @@ __________.__                   __
             $gciParams = @{}
             $parent = Split-Path $srcRelPath -Parent
             $leaf = Split-Path $srcRelPath -Leaf
-            $gciParams['LiteralPath'] = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($parent)
+            $gciParams['LiteralPath'] = $PSCmdlet.GetUnresolvedProviderPathFromPSPath((Join-Path $TemplatePath $parent))
             $gciParams['File'] = $true
 
             if ($leaf -eq '**') {
@@ -462,7 +462,7 @@ __________.__                   __
                 $leaf = Split-Path $parent -Leaf
                 if ($leaf -eq '**') {
                     $parent = Split-Path $parent -Parent
-                    $gciParams['LiteralPath'] = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($parent)
+                    $gciParams['LiteralPath'] = $PSCmdlet.GetUnresolvedProviderPathFromPSPath((Join-Path $TemplatePath $parent))
                     $gciParams['Recurse'] = $true
                 }
             }


### PR DESCRIPTION
Fixes #27 

If you Invoke-Plaster with a working directory outside of the TemplatePath, Plaster does not Join the TemplatePath and Folder to be recursed. So when it resolves the path, it resolves to the current working directory and it errors because it can't find the path.

The fix Joins the TemplatePath and Source Relative Path Parent.