### PR TITLE
Add script signing tasks

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -220,7 +220,7 @@ Task ShowFullKey -requiredVariables EncryptedApiKeyPath {
         "The embedded NuGetApiKey is: $NuGetApiKey"
     }
     else {
-        $NuGetApiKey = LoadAndUnencryptNuGetApiKey -Path $EncryptedApiKeyPath
+        $NuGetApiKey = LoadAndUnencryptString -Path $EncryptedApiKeyPath
         "The stored NuGetApiKey is: $NuGetApiKey"
     }
 }

--- a/Build.ps1
+++ b/Build.ps1
@@ -246,7 +246,7 @@ Task Sign -depends Test -requiredVariables CertSubjectPath {
         $CertImport = @{
             CertStoreLocation = 'Cert:\CurrentUser\My'
             FilePath          = $CertPfxPath
-            Password          = $(Get-Credential).Password
+            Password          = $(PromptUserForKeyCredential -Message 'Enter the PFX password to import the certificate').Password
             ErrorAction       = 'Stop'
         }
 


### PR DESCRIPTION
Working towards #33.

This allows a couple of different ways of setting up the script signing process, piggybacking on the existing functions for storing/retrieving clixml data.

You can pass the CertThumbprint parameter through psake to select a specific certificate from Cert:\CurrentUser\My\. This is stored in $env:LOCALAPPDATA\WindowsPowerShell\CertificateThumbprint.clixml, like the nuget API key for automatic use next time.

Alternatively, a path to a PFX file can be used and a password will be asked for or can be provided through a psake parameter.

There is a final fallback behaviour that selects the first available code signing cert from the current user store, but I'm unsure about this, as I added it early on, but it seems a bit less useful now.

I also added the utility tasks to show or remove the stored certificate thumbprint.