### PR TITLE
Provide a generic build settings key/value store

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -99,18 +99,18 @@ Properties {
     # store the key encrypted in a file, so that on subsequent publishes you
     # will no longer be prompted for the API key.
     $NuGetApiKey = $null
-    $EncryptedApiKeyPath = "$env:LOCALAPPDATA\vscode-powershell\NuGetApiKey.clixml"
 
     # If you specify the certificate subject when running a build that certificate 
     # must exist in the users personal certificate store. The build will import the 
     # certificate (if required), then store the subject, so that on subsequent 
     # signing the build will use the same (or newer) certificate with that subject.
-    $CertSubjectPath  = "$env:LOCALAPPDATA\WindowsPowerShell\CertificateSubject.clixml"
+    $CertSubject = $null
 
     # In addition, PFX certificates are supported in an interactive scenario only,
     # as a way to import a certificate into the user personal store for later use.
     # This can be provided using the CertPfxPath parameter.
     # PFX passwords will not be stored.
+    $SecuredSettingsPath = "$env:LOCALAPPDATA\WindowsPowerShell\SecuredSettings.clixml"
 }
 
 ###############################################################################
@@ -131,22 +131,23 @@ Task default -depends Build
 Task Publish -depends Test, PrePublish, PublishImpl, PostPublish {
 }
 
-Task PublishImpl -depends Test -requiredVariables EncryptedApiKeyPath, PublishDir {
+Task PublishImpl -depends Test -requiredVariables SecuredSettingsPath, PublishDir {
     if ($NuGetApiKey) {
         "Using script embedded NuGetApiKey"
     }
-    elseif (Test-Path -LiteralPath $EncryptedApiKeyPath) {
-        $NuGetApiKey = LoadAndUnencryptString $EncryptedApiKeyPath
+    elseif (GetSecuredSetting -Path $SecuredSettingsPath -Key NuGetApiKey) {
+        $NuGetApiKey = GetSecuredSetting -Path $SecuredSettingsPath -Key NuGetApiKey
         "Using stored NuGetApiKey"
     }
     else {
         $KeyCred = @{
-            DestinationPath = $EncryptedApiKeyPath
+            DestinationPath = $SecuredSettingsPath
             Message         = 'Enter your NuGet API key in the password field'
+            Key             = 'NuGetApiKey'
         }
         $cred = PromptUserForKeyCredential @KeyCred
         $NuGetApiKey = $cred.GetNetworkCredential().Password
-        "The NuGetApiKey has been stored in $EncryptedApiKeyPath"
+        "The NuGetApiKey has been stored in $SecuredSettingsPath"
     }
 
     $publishParams = @{
@@ -199,39 +200,39 @@ Task Init -requiredVariables PublishDir {
     }
 }
 
-Task RemoveKey -requiredVariables EncryptedApiKeyPath {
-    if (Test-Path -LiteralPath $EncryptedApiKeyPath) {
-        Remove-Item -LiteralPath $EncryptedApiKeyPath
+Task RemoveKey -requiredVariables SecuredSettingsPath {
+    if (GetSecuredSetting -Path $SecuredSettingsPath -Key NuGetApiKey) {
+        RemoveSecuredSetting -Path $SecuredSettingsPath -Key NuGetApiKey
     }
 }
 
-Task StoreKey -requiredVariables EncryptedApiKeyPath {
+Task StoreKey -requiredVariables SecuredSettingsPath {
     $KeyCred = @{
-        DestinationPath = $EncryptedApiKeyPath
-        Message = 'Enter your NuGet API key in the password field'
+        DestinationPath = $SecuredSettingsPath
+        Message         = 'Enter your NuGet API key in the password field'
+        Key             = 'NuGetApiKey'
     }
     PromptUserForKeyCredential @KeyCred
-    "The NuGetApiKey has been stored in $EncryptedApiKeyPath"
+    "The NuGetApiKey has been stored in $SecuredSettingsPath"
 }
 
-Task ShowKey -requiredVariables EncryptedApiKeyPath {
+Task ShowKey -requiredVariables SecuredSettingsPath {
     if ($NuGetApiKey) {
         "The embedded (partial) NuGetApiKey is: $($NuGetApiKey[0..7])"
     }
     else {
-        $NuGetApiKey = LoadAndUnencryptString -Path $EncryptedApiKeyPath
+        $NuGetApiKey = GetSecuredSetting -Path $SecuredSettingsPath -Key NuGetApiKey
         "The stored (partial) NuGetApiKey is: $($NuGetApiKey[0..7])"
     }
-
-    "To see the full key, use the task 'ShowFullKey'"
+    Write-Output "To see the full key, use the task 'ShowFullKey'"
 }
 
-Task ShowFullKey -requiredVariables EncryptedApiKeyPath {
+Task ShowFullKey -requiredVariables SecuredSettingsPath {
     if ($NuGetApiKey) {
         "The embedded NuGetApiKey is: $NuGetApiKey"
     }
     else {
-        $NuGetApiKey = LoadAndUnencryptString -Path $EncryptedApiKeyPath
+        $NuGetApiKey = GetSecuredSetting -Path $SecuredSettingsPath -Key NuGetApiKey
         "The stored NuGetApiKey is: $NuGetApiKey"
     }
 }
@@ -241,7 +242,7 @@ Task ? -description 'Lists the available tasks' {
     $PSake.Context.Peek().Tasks.Keys | Sort-Object
 }
 
-Task Sign -depends Test -requiredVariables CertSubjectPath {
+Task Sign -depends Test -requiredVariables SecuredSettingsPath {
     if ($CertPfxPath) {
         $CertImport = @{
             CertStoreLocation = 'Cert:\CurrentUser\My'
@@ -253,8 +254,8 @@ Task Sign -depends Test -requiredVariables CertSubjectPath {
         $Cert = Import-PfxCertificate @CertImport -Verbose:$VerbosePreference
     }
     else {
-        if ($CertSubject -eq $null -and (Test-Path -LiteralPath $CertSubjectPath)) {
-            $CertSubject = LoadAndUnencryptString $CertSubjectPath
+        if ($CertSubject -eq $null -and (GetSecuredSetting -Key CertSubject -Path $SecuredSettingsPath)) {
+            $CertSubject = GetSecuredSetting -Key CertSubject -Path $SecuredSettingsPath
             $LoadedFromSubjectFile = $true
         }
         else {
@@ -269,11 +270,11 @@ Task Sign -depends Test -requiredVariables CertSubjectPath {
     
     if ($Cert) {
         if (-not $LoadedFromSubjectFile) {
-            EncryptAndSaveString -String $Cert.Subject -Path $CertSubjectPath
-            Write-Output "The new certificate subject has been stored in $CertSubjectPath"
+            AddSecuredSetting -Key CertSubject -String $Cert.Subject -Path $SecuredSettingsPath
+            Write-Output "The new certificate subject has been stored in $SecuredSettingsPath"
         }
         else {
-            Write-Output "Using stored certificate subject $CertSubject from $CertSubjectPath"
+            Write-Output "Using stored certificate subject $CertSubject from $SecuredSettingsPath"
         }
 
         $Authenticode   = @{
@@ -294,14 +295,14 @@ Task Sign -depends Test -requiredVariables CertSubjectPath {
     }
 }
 
-Task RemoveCertSubject -requiredVariables CertSubjectPath {
-    if (Test-Path -LiteralPath $CertSubjectPath) {
-        Remove-Item -LiteralPath $CertSubjectPath
+Task RemoveCertSubject -requiredVariables SecuredSettingsPath {
+    if (GetSecuredSetting -Path $SecuredSettingsPath -Key CertSubject) {
+        RemoveSecuredSetting -Path $SecuredSettingsPath -Key CertSubject
     }
 }
 
-Task ShowCertSubject -requiredVariables CertSubjectPath {
-    $CertSubject = LoadAndUnencryptString -Path $CertSubjectPath
+Task ShowCertSubject -requiredVariables SecuredSettingsPath {
+    $CertSubject = GetSecuredSetting -Path $SecuredSettingsPath -Key CertSubject
     Write-Output "The stored certificate is: $CertSubject"
     $Cert = Get-ChildItem -Path Cert:\CurrentUser\My -CodeSigningCert |
             Where-Object { $_.Subject -eq $CertSubject -and $_.NotAfter -gt (Get-Date) } |
@@ -333,63 +334,94 @@ function PromptUserForKeyCredential {
 
         [Parameter(Mandatory)]
         [string]
-        $Message
+        $Message,
+
+        [Parameter(Mandatory, ParameterSetName = 'SaveSetting')]
+        [string]
+        $Key
     )
 
     $KeyCred = Get-Credential -Message $Message -UserName "ignored"
-
     if ($DestinationPath) {
-        EncryptAndSaveString -SecureString $KeyCred.Password -Path $DestinationPath
+        AddSecuredSetting -SecureString $KeyCred.Password -Path $DestinationPath -Key $Key
     }
 
     $KeyCred
 }
 
-function EncryptAndSaveString {
+function AddSecuredSetting {
+    [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessage("PSAvoidUsingConvertToSecureStringWithPlainText", '')]
-    [Diagnostics.CodeAnalysis.SuppressMessage("PSProvideDefaultParameterValue", '')]
-    param(
+    Param(
+        [Parameter(Mandatory)]
+        [string]$Key,
+
+        [Parameter(Mandatory)]
+        [string]$Path,
+
         [Parameter(Mandatory, ParameterSetName='SecureString')]
         [ValidateNotNull()]
-        [SecureString]
-        $SecureString,
+        [SecureString]$SecureString,
 
         [Parameter(Mandatory, ParameterSetName='PlainText')]
         [ValidateNotNullOrEmpty()]
-        [string]
-        $String,
-
-        [Parameter(Mandatory)]
-        $Path
+        [string]$String
     )
 
-    if ($PSCmdlet.ParameterSetName -eq 'PlainText') {
+    if ($String) {
         $SecureString = ConvertTo-SecureString -String $String -AsPlainText -Force
     }
 
-    $parentDir = Split-Path $Path -Parent
-    if (!(Test-Path -LiteralPath $parentDir)) {
-        $null = New-Item -Path $parentDir -ItemType Directory
+    if (Test-Path -Path $Path) {
+        $StoredSettings = Import-Clixml -Path $Path
+        $StoredSettings.Add($Key, ($SecureString | ConvertFrom-SecureString))
+        $StoredSettings | Export-Clixml -Path $Path
     }
-    elseif (Test-Path -LiteralPath $Path) {
-        Remove-Item -LiteralPath $Path
+    else {
+        @{$Key = ($SecureString | ConvertFrom-SecureString)} | Export-Clixml -Path $Path
     }
-
-    $SecureString | ConvertFrom-SecureString | Export-Clixml $Path
-    Write-Verbose "The data has been encrypted and saved to $Path"
 }
 
-function LoadAndUnencryptString {
-    [Diagnostics.CodeAnalysis.SuppressMessage("PSProvideDefaultParameterValue", '')]
-    param(
+function GetSecuredSetting {
+    [CmdletBinding()]
+    Param(
         [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
+        [string]
+        $Key,
+
+        [Parameter(Mandatory)]
         [string]
         $Path
     )
 
-    $storedKey = Import-Clixml $Path | ConvertTo-SecureString
-    $cred = New-Object -TypeName PSCredential -ArgumentList 'jpgr',$storedKey
-    $cred.GetNetworkCredential().Password
-    Write-Verbose "The data has been loaded and unencrypted from $Path"
+    if (Test-Path -Path $Path) {
+        $SecuredSettings = Import-Clixml -Path $Path
+        if ($SecuredSettings.$Key) {
+            $Value = $SecuredSettings.$Key | ConvertTo-SecureString
+            $cred = New-Object -TypeName PSCredential -ArgumentList 'jpgr', $Value
+            $cred.GetNetworkCredential().Password
+        }
+    }
+}
+
+function RemoveSecuredSetting {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory)]
+        [string]
+        $Key,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Path
+    )
+
+    $StoredSettings = Import-Clixml -Path $Path
+    $StoredSettings.Remove($Key)
+    if ($StoredSettings.Count -eq 0) {
+        Remove-Item -Path $Path
+    }
+    else {
+        $StoredSettings | Export-Clixml -Path $Path
+    }
 }


### PR DESCRIPTION
A little bit of work to provide a generic key/value store for build settings based on the [suggestion](https://github.com/PowerShell/Plaster/pull/34#discussion_r68600243) from @rkeithhill.

These functions may also be useful as a starting point to provide stored settings for #9, as there is the potential for storing arbitrary objects with a little bit of work.