### PR TITLE
Modify now uses conflict res

### DIFF
--- a/examples/NewModuleTemplate/Tests/Module.T.ps1
+++ b/examples/NewModuleTemplate/Tests/Module.T.ps1
@@ -1,5 +1,4 @@
 $ModuleManifestName = '<%=$PLASTER_PARAM_ModuleName%>.psd1'
-# <%=${PLASTER_GUID1}%> - testing use of PLASTER predefined variables.
 Import-Module $PSScriptRoot\..\$ModuleManifestName
 
 Describe 'Module Manifest Tests' {

--- a/src/Plaster.psm1
+++ b/src/Plaster.psm1
@@ -19,10 +19,14 @@ $LocalizedData = data {
     ManifestWrongFilename_F1=The Plaster manifest filename '{0}' is not valid. The value of the Path argument must refer to a file named 'plasterManifest.xml'. Change the plaster manifest filename to 'plasterManifest.xml', and then try again.
     OpCreate=Create
     OpConflict=Conflict
-    OpExpand=Expand
+    OpExpand=Expanding
     OpIdentical=Identical
-    OpModify=Modify
+    OpModify=Modifying
+    OpUpdate=Update
+    OpMessageConflict_F1=with existing file {0}
+    OpMessageIdentical_F1=to existing file {0}
     OverwriteFile_F1=Overwrite {0}
+    TempFileOperation_F1={0} into a temp file
     ParameterTypeChoiceMultipleDefault_F1=Parameter name {0} is of type='choice' and can only have one default value.
     ShouldProcessCreateDir=Create directory
     ShouldProcessGenerateModuleManifest=Generate new module manifest

--- a/src/en-US/Plaster.Resources.psd1
+++ b/src/en-US/Plaster.Resources.psd1
@@ -18,10 +18,14 @@ ManifestNotWellFormedXml_F2=The Plaster manifest '{0}' is not a well-formed XML 
 ManifestWrongFilename_F1=The Plaster manifest filename '{0}' is not valid. The value of the Path argument must refer to a file named 'plasterManifest.xml'. Change the plaster manifest filename to 'plasterManifest.xml', and then try again.
 OpCreate=Create
 OpConflict=Conflict
-OpExpand=Expand
+OpExpand=Expanding
 OpIdentical=Identical
-OpModify=Modify
+OpModify=Modifying
+OpUpdate=Update
+OpMessageConflict_F1=with existing file {0}
+OpMessageIdentical_F1=to existing file {0}
 OverwriteFile_F1=Overwrite {0}
+TempFileOperation_F1={0} into a temp file
 ParameterTypeChoiceMultipleDefault_F1=Parameter name {0} is of type='choice' and can only have one default value.
 ShouldProcessCreateDir=Create directory
 ShouldProcessGenerateModuleManifest=Generate new module manifest


### PR DESCRIPTION
This was a bit of a significant change and caused me to add several features.  When a file is modified that the template added previously, the operation is now called "Update" and  will not result in a conflict.  If the file pre-existed the application of the template then normal file conflict detect/res comes into play.  Also changed color of "intermediate" ops like Expanding and Modifying to display in Magenta to distinguish them from the Green of create.  Expand and modify now do their work in temp files. Then temp files are then passed to the file conflict detect/res script.

Without these changes the combo on <file source="tasks.json"..> and <modify path="tasks.json"..> would result in a conflict that need to be answered during a template invoke on an empy dest directory. Clearly this was not desirable.