### PR TITLE
Fix #76 - improve error handling

### DIFF
--- a/src/Plaster.psm1
+++ b/src/Plaster.psm1
@@ -4,7 +4,8 @@ data LocalizedData {
     # culture="en-US"
     ConvertFrom-StringData @'
     ErrorFailedToLoadStoreFile_F1=Failed to load the default value store file: '{0}'.
-    ErrorProcessingDynamicParams_F1=Error processing dynamic parameters: {0}
+    ErrorProcessingDynamicParams_F1=Failed to create dynamic parameters from the template's manifest file.  Template-based dynamic parameters will not be available until the error is corrected.  The error was: {0}
+    ErrorTemplatePathIsInvalid_F1=The TemplatePath parameter value must refer to an existing directory. The specified path '{0}' does not.
     ErrorUnencryptingSecureString_F1=Failed to unencrypt value for parameter '{0}'.
     ErrorPathDoesNotExist_F1=Cannot find path '{0}' because it does not exist.
     ErrorPathMustBeUnderDestPath_F2=The path '{0}' must be under the specified DestinationPath '{1}'.

--- a/src/en-US/Plaster.Resources.psd1
+++ b/src/en-US/Plaster.Resources.psd1
@@ -3,7 +3,8 @@
 ConvertFrom-StringData @'
 ###PSLOC
 ErrorFailedToLoadStoreFile_F1=Failed to load the default value store file: '{0}'.
-ErrorProcessingDynamicParams_F1=Error processing dynamic parameters: {0}
+ErrorProcessingDynamicParams_F1=Failed to create dynamic parameters from the template's manifest file.  Template-based dynamic parameters will not be available until the error is corrected.  The error was: {0}
+ErrorTemplatePathIsInvalid_F1=The TemplatePath parameter value must refer to an existing directory. The specified path '{0}' does not.
 ErrorUnencryptingSecureString_F1=Failed to unencrypt value for parameter '{0}'.
 ErrorPathDoesNotExist_F1=Cannot find path '{0}' because it does not exist.
 ErrorPathMustBeUnderDestPath_F2=The path '{0}' must be under the specified DestinationPath '{1}'.

--- a/test/ManifestValidation.Tests.ps1
+++ b/test/ManifestValidation.Tests.ps1
@@ -11,17 +11,17 @@ Describe 'Module Error Handling Tests' {
         It 'Throws on not well-formed XML manifest file' {
             CleanDir $TemplateDir
             Copy-Item $PSScriptRoot\Manifests\plasterManifestNotWellFormedXml.xml $TemplateDir\plasterManifest.xml
-            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 3>$null } | Should Throw
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo *>$null } | Should Throw
         }
         It 'Throws on missing plasterManifest (root) element' {
             CleanDir $TemplateDir
             Copy-Item $PSScriptRoot\Manifests\plasterManifestMissingRoot.xml $TemplateDir\plasterManifest.xml
-            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo } | Should Throw
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo *>$null } | Should Throw
         }
         It 'Throws on missing target namespace on (root) element' {
             CleanDir $TemplateDir
             Copy-Item $PSScriptRoot\Manifests\plasterManifestNoTargetNamespace.xml $TemplateDir\plasterManifest.xml
-            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo } | Should Throw
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo *>$null } | Should Throw
         }
         It 'Throws on missing metadata element' {
             CleanDir $TemplateDir


### PR DESCRIPTION
Primarily for Invalid TemplatePath argument and invalid manifest files interaction with dynamicparam.  Try to provide some indication of what went wrong.