### PR TITLE
Add err handling for manifest specified paths.

### DIFF
--- a/src/Plaster.psm1
+++ b/src/Plaster.psm1
@@ -1,4 +1,3 @@
-#Microsoft.PowerShell.Core\Set-StrictMode -Version Latest
 
 data LocalizedData {
     # culture="en-US"
@@ -8,6 +7,7 @@ data LocalizedData {
     ErrorTemplatePathIsInvalid_F1=The TemplatePath parameter value must refer to an existing directory. The specified path '{0}' does not.
     ErrorUnencryptingSecureString_F1=Failed to unencrypt value for parameter '{0}'.
     ErrorPathDoesNotExist_F1=Cannot find path '{0}' because it does not exist.
+    ErrorPathMustBeRelativePath_F2=The path '{0}' specified in the {1} directive in the template manifest cannot be an absolute path.  Change the path to a relative path.
     ErrorPathMustBeUnderDestPath_F2=The path '{0}' must be under the specified DestinationPath '{1}'.
     FileConflict=Plaster file conflict
     ManifestFileMissing_F1=The Plaster manifest file '{0}' was not found.

--- a/src/en-US/Plaster.Resources.psd1
+++ b/src/en-US/Plaster.Resources.psd1
@@ -7,6 +7,7 @@ ErrorProcessingDynamicParams_F1=Failed to create dynamic parameters from the tem
 ErrorTemplatePathIsInvalid_F1=The TemplatePath parameter value must refer to an existing directory. The specified path '{0}' does not.
 ErrorUnencryptingSecureString_F1=Failed to unencrypt value for parameter '{0}'.
 ErrorPathDoesNotExist_F1=Cannot find path '{0}' because it does not exist.
+ErrorPathMustBeRelativePath_F2=The path '{0}' specified in the {1} directive in the template manifest cannot be an absolute path.  Change the path to a relative path.
 ErrorPathMustBeUnderDestPath_F2=The path '{0}' must be under the specified DestinationPath '{1}'.
 FileConflict=Plaster file conflict
 ManifestFileMissing_F1=The Plaster manifest file '{0}' was not found.

--- a/test/ManifestValidation.Tests.ps1
+++ b/test/ManifestValidation.Tests.ps1
@@ -51,4 +51,37 @@ Describe 'Module Error Handling Tests' {
             { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 3>$null} | Should Throw
         }
     }
+
+    Context 'Template cannot write outside of the user-specified DestinationPath' {
+        It 'Throws on modify path that is absolute path' {
+            CleanDir $TemplateDir
+            Copy-Item $PSScriptRoot\Manifests\modifyAbsolutePath.xml $TemplateDir\plasterManifest.xml
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+        }
+        It 'Throws on newModuleManifest destination that is absolute path' {
+            CleanDir $TemplateDir
+            Copy-Item $PSScriptRoot\Manifests\newModManifestAbsolutePath.xml $TemplateDir\plasterManifest.xml
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+        }
+        It 'Throws on templateFile destination that is absolute path' {
+            CleanDir $TemplateDir
+            Copy-Item $PSScriptRoot\Manifests\templateFileAbsolutePath.xml $TemplateDir\plasterManifest.xml
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+        }
+        It 'Throws on modify relativePath outside of DestinationPath' {
+            CleanDir $TemplateDir
+            Copy-Item $PSScriptRoot\Manifests\modifyOutsideDestPath.xml $TemplateDir\plasterManifest.xml
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+        }
+        It 'Throws on newModuleManifest relativePath outside of DestinationPath' {
+            CleanDir $TemplateDir
+            Copy-Item $PSScriptRoot\Manifests\newModManOutsideDestPath.xml $TemplateDir\plasterManifest.xml
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+        }
+        It 'Throws on templateFile relativePath outside of DestinationPath' {
+            CleanDir $TemplateDir
+            Copy-Item $PSScriptRoot\Manifests\templateFileOutsideDestPath.xml $TemplateDir\plasterManifest.xml
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+        }
+    }
 }

--- a/test/Manifests/modifyAbsolutePath.xml
+++ b/test/Manifests/modifyAbsolutePath.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="0.3" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+    <metadata>
+        <id>513d2fdc-3cce-47d9-9531-d85114efb224</id>
+        <title>Testing</title>
+        <description>Manifest file for testing.</description>
+        <version>0.2.0</version>
+        <tags></tags>
+    </metadata>
+    <content>
+        <modify path='$env:LOCALAPPDATA\tasks-should-not-be-here.json' encoding='UTF8'
+                condition="$false">
+            <replace>
+                <original>(?s)^(.*)</original>
+                <substitute expand='true'>``$1`r`n// Author: John Doe</substitute>
+            </replace>
+        </modify>
+    </content>
+</plasterManifest>

--- a/test/Manifests/modifyOutsideDestPath.xml
+++ b/test/Manifests/modifyOutsideDestPath.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="0.3" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+    <metadata>
+        <id>513d2fdc-3cce-47d9-9531-d85114efb224</id>
+        <title>Testing</title>
+        <description>Manifest file for testing.</description>
+        <version>0.2.0</version>
+        <tags></tags>
+    </metadata>
+    <content>
+        <modify path='..\tasks-should-not-be-here.json' encoding='UTF8'
+                condition="$false">
+            <replace>
+                <original>(?s)^(.*)</original>
+                <substitute expand='true'>``$1`r`n// Author: John Doe</substitute>
+            </replace>
+        </modify>
+    </content>
+</plasterManifest>

--- a/test/Manifests/newModManOutsideDestPath.xml
+++ b/test/Manifests/newModManOutsideDestPath.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="0.3" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+    <metadata>
+        <id>513d2fdc-3cce-47d9-9531-d85114efb224</id>
+        <title>Testing</title>
+        <description>Manifest file for testing.</description>
+        <version>0.2.0</version>
+        <tags></tags>
+    </metadata>
+    <content>
+        <newModuleManifest destination='..\foo-should-not-be-here.psd1'
+                           moduleVersion='1.2.3.4'
+                           rootModule='foo.psm1'
+                           encoding='UTF8-NoBOM'/>
+    </content>
+</plasterManifest>

--- a/test/Manifests/newModManifestAbsolutePath.xml
+++ b/test/Manifests/newModManifestAbsolutePath.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="0.3" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+    <metadata>
+        <id>513d2fdc-3cce-47d9-9531-d85114efb224</id>
+        <title>Testing</title>
+        <description>Manifest file for testing.</description>
+        <version>0.2.0</version>
+        <tags></tags>
+    </metadata>
+    <content>
+        <newModuleManifest destination='$env:LOCALAPPDATA\foo-should-not-be-here.psd1'
+                           moduleVersion='1.2.3.4'
+                           rootModule='foo.psm1'
+                           encoding='UTF8-NoBOM'/>
+    </content>
+</plasterManifest>

--- a/test/Manifests/templateFileAbsolutePath.xml
+++ b/test/Manifests/templateFileAbsolutePath.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="0.3" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+    <metadata>
+        <id>513d2fdc-3cce-47d9-9531-d85114efb224</id>
+        <title>Testing</title>
+        <description>Manifest file for testing.</description>
+        <version>0.2.0</version>
+        <tags></tags>
+    </metadata>
+    <content>
+        <templateFile source='Recurse\a\foo.txt' destination='${Env:LocalAppData}\PlasterTest-ShouldNotBeHere.txt'/>
+    </content>
+</plasterManifest>

--- a/test/Manifests/templateFileOutsideDestPath.xml
+++ b/test/Manifests/templateFileOutsideDestPath.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="0.3" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+    <metadata>
+        <id>513d2fdc-3cce-47d9-9531-d85114efb224</id>
+        <title>Testing</title>
+        <description>Manifest file for testing.</description>
+        <version>0.2.0</version>
+        <tags></tags>
+    </metadata>
+    <content>
+        <templateFile source='Recurse\a\foo.txt' destination='..\foo-should-not-be-here.txt'/>
+    </content>
+</plasterManifest>


### PR DESCRIPTION
Fix #81.  This commit adds checks for both absolute paths (not allowed) and relative paths that try to specify dirs outside of the user specified DestinationPath e.g. ..\..\..\windows\system32.

Also added a number of Pester tests to make sure the various directives that use paths, error appropriately.