### PR TITLE
Add Test-Path and FileSystem provider to runspace

### DIFF
--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -1102,9 +1102,9 @@ function NewConstrainedRunspace() {
         $iss.Variables.Add($ssve)
     }
 
-    # Create new runspace withe defined entries, open and set its working dir to $DestinationPath
-    # so all condition attriute expressions can use a relative path to refer to file paths e.g.
-    # Test-Path src\${PLASTER_PARAM_ModuleName}.psm1
+    # Create new runspace with the above defined entries. Then open and set its working dir to $DestinationAbsolutePath
+    # so all condition attribute expressions can use a relative path to refer to file paths e.g.
+    # condition="Test-Path src\${PLASTER_PARAM_ModuleName}.psm1"
     $runspace = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace($iss)
     $runspace.Open()
     if ($script:DestinationAbsolutePath) {

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -76,7 +76,7 @@ function Invoke-Plaster {
             # catch and format the error message as a warning.
             $ErrorActionPreference = 'Stop'
 
-            # Needs to be set for the ConstrainedRunspace to have its working directoyr set correctly.
+            # Needs to be set for the ConstrainedRunspace to have its working directory set correctly.
             $script:DestinationAbsolutePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($DestinationPath)
 
             $resolvedTemplatePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($TemplatePath)

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -14,6 +14,7 @@ Please follow the scripting style of this file when adding new script.
 
 # Constrained runspace used to expand manifest attribute strings and evaluates conditions
 $ConstrainedRunspace = $null
+$DestinationAbsolutePath = $null
 
 <#
 .SYNOPSIS
@@ -74,6 +75,9 @@ function Invoke-Plaster {
             # Let's convert non-terminating errors in this function to terminating so we
             # catch and format the error message as a warning.
             $ErrorActionPreference = 'Stop'
+
+            # Needs to be set for the ConstrainedRunspace to have its working directoyr set correctly.
+            $script:DestinationAbsolutePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($DestinationPath)
 
             $resolvedTemplatePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($TemplatePath)
             if (!(Test-Path -LiteralPath $resolvedTemplatePath -PathType Container)) {
@@ -194,7 +198,8 @@ function Invoke-Plaster {
             Write-Host ("=" * 50)
         }
 
-        InitializePredefinedVariables $PSCmdlet.GetUnresolvedProviderPathFromPSPath($DestinationPath)
+        $script:DestinationAbsolutePath = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($DestinationPath)
+        InitializePredefinedVariables $script:DestinationAbsolutePath
 
         # Check for any existing default value store file and load default values if file exists.
         $templateId = $manifest.plasterManifest.metadata.id
@@ -987,10 +992,10 @@ function Invoke-Plaster {
             }
         }
         finally {
-            # Dispose of the constrained runspace.
-            if ($script:Runspace) {
-                $script.Runspace.Dispose()
-                $script.Runspace = $null
+            # Dispose of the ConstrainedRunspace.
+            if ($script:ConstrainedRunspace) {
+                $script:ConstrainedRunspace.Dispose()
+                $script:ConstrainedRunspace = $null
             }
         }
     }
@@ -1004,12 +1009,12 @@ function Invoke-Plaster {
 ██   ██ ███████ ███████ ██      ███████ ██   ██ ███████
 #>
 
-function InitializePredefinedVariables([string]$destPath) {
+function InitializePredefinedVariables([string]$DestPath) {
     # Always set these variables, even if the command has been run with -WhatIf
     $WhatIfPreference = $false
 
-    $destName = Split-Path -Path $destPath -Leaf
-    Set-Variable -Name PLASTER_DestinationPath -Value $destPath.TrimEnd('\','/') -Scope Script
+    $destName = Split-Path -Path $DestPath -Leaf
+    Set-Variable -Name PLASTER_DestinationPath -Value $DestPath.TrimEnd('\','/') -Scope Script
     Set-Variable -Name PLASTER_DestinationName -Value $destName -Scope Script
     Set-Variable -Name PLASTER_HostName        -Value $Host.Name -Scope Script
 
@@ -1065,6 +1070,9 @@ function NewConstrainedRunspace() {
     $sspe = New-Object System.Management.Automation.Runspaces.SessionStateProviderEntry 'Environment',([Microsoft.PowerShell.Commands.EnvironmentProvider]),$null
     $iss.Providers.Add($sspe)
 
+    $sspe = New-Object System.Management.Automation.Runspaces.SessionStateProviderEntry 'FileSystem',([Microsoft.PowerShell.Commands.FileSystemProvider]),$null
+    $iss.Providers.Add($sspe)
+
     # Uncomment for debugging runspace capabilities
     # $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Command',([Microsoft.PowerShell.Commands.GetCommandCommand]),$null
     # $iss.Commands.Add($ssce)
@@ -1084,6 +1092,9 @@ function NewConstrainedRunspace() {
     $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Module',([Microsoft.PowerShell.Commands.GetModuleCommand]),$null
     $iss.Commands.Add($ssce)
 
+    $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Test-Path',([Microsoft.PowerShell.Commands.TestPathCommand]),$null
+    $iss.Commands.Add($ssce)
+
     $scopedItemOptions = [System.Management.Automation.ScopedItemOptions]::AllScope
     $plasterVars = Get-Variable -Name PLASTER_*
     foreach ($var in $plasterVars) {
@@ -1091,8 +1102,14 @@ function NewConstrainedRunspace() {
         $iss.Variables.Add($ssve)
     }
 
+    # Create new runspace withe defined entries, open and set its working dir to $DestinationPath
+    # so all condition attriute expressions can use a relative path to refer to file paths e.g.
+    # Test-Path src\${PLASTER_PARAM_ModuleName}.psm1
     $runspace = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace($iss)
     $runspace.Open()
+    if ($script:DestinationAbsolutePath) {
+        $runspace.SessionStateProxy.Path.SetLocation($script:DestinationAbsolutePath) > $null
+    }
     $runspace
 }
 

--- a/test/ConditionEval.Tests.ps1
+++ b/test/ConditionEval.Tests.ps1
@@ -1,0 +1,60 @@
+. $PSScriptRoot\Shared.ps1
+
+Describe 'Condition Attribute Evaluation Tests' {
+    Context 'Runspace FileSystem provider working' {
+        It 'Determines non-existing file is actually not in destination path' {
+            CleanDir $TemplateDir
+            CleanDir $OutDir
+
+            @"
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="0.3" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+    <metadata>
+        <name>TemplateName</name>
+        <id>513d2fdc-3cce-47d9-9531-d85114efb224</id>
+        <version>0.2.0</version>
+        <title>Testing</title>
+        <description>Manifest file for testing.</description>
+        <tags></tags>
+    </metadata>
+    <content>
+        <file source='Recurse\foo.txt' destination='foo.txt' condition='Test-Path bar.txt'/>
+    </content>
+</plasterManifest>
+"@ | Out-File $PlasterManifestPath -Encoding utf8
+
+            Copy-Item $PSScriptRoot\Recurse $TemplateDir -Recurse
+            Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6> $null
+            # condition should return false (file doesn't exist) which will not copy over the file foo.txt
+            Get-Item $OutDir\foo.txt -ErrorAction SilentlyContinue | Should BeNullOrEmpty
+        }
+
+        It 'Determines existing file is in destination path' {
+            CleanDir $TemplateDir
+            CleanDir $OutDir
+
+            @"
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="0.3" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+    <metadata>
+        <name>TemplateName</name>
+        <id>513d2fdc-3cce-47d9-9531-d85114efb224</id>
+        <version>0.2.0</version>
+        <title>Testing</title>
+        <description>Manifest file for testing.</description>
+        <tags></tags>
+    </metadata>
+    <content>
+        <file source='Recurse\foo.txt' destination='foo.txt' condition='Test-Path bar.txt'/>
+    </content>
+</plasterManifest>
+"@ | Out-File $PlasterManifestPath -Encoding utf8
+
+            Copy-Item $PSScriptRoot\Recurse $TemplateDir -Recurse
+            New-Item $OutDir\bar.txt -ItemType File > $null
+            Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6> $null
+            # condition should return true which will copy over the file foo.txt
+            Get-Item $OutDir\foo.txt -ErrorAction SilentlyContinue | Foreach-Object Name | Should BeExactly foo.txt
+        }
+    }
+}


### PR DESCRIPTION
This enhances the constrained runspace to allow the template author to use the Test-Path command to direct the actions of the template depending on whether certain files already exist in the destination path.  Added basic set of tests for Test-Path command availability.  

Also fixed a bug where we weren't disposing of the last runspace created right before the Invoke-Plaster command exits.