### PR TITLE
Refactored function locations in Invoke-Plaster.

### DIFF
--- a/examples/DebugNewModuleTemplate.ps1
+++ b/examples/DebugNewModuleTemplate.ps1
@@ -23,3 +23,4 @@ $PlasterParams = @{
 }
 
 Invoke-Plaster @PlasterParams -Force
+#Invoke-Plaster -TemplatePath $PSScriptRoot\NewModuleTemplate -DestinationPath Out


### PR DESCRIPTION
Moved the constrained runspace, expand string and evaluate condition functions inside the begin block so I could get rid of the script scoped variables for constrainedRunspace, templateAbsolutePath and destinationAbsolutePath.