### PR TITLE
Add module help tests to Plaster and template(s)

### DIFF
--- a/examples/NewModuleTemplate/Tests/Help.Tests.ps1
+++ b/examples/NewModuleTemplate/Tests/Help.Tests.ps1
@@ -1,0 +1,188 @@
+<#	
+	.NOTES
+		===========================================================================
+		Created with: 	SAPIEN Technologies, Inc., PowerShell Studio 2016 v5.2.119
+		Created on:   	4/12/2016 1:11 PM
+		Created by:   	June Blender
+		Organization: 	SAPIEN Technologies, Inc
+		Filename:		*.Help.Tests.ps1
+		===========================================================================
+	.DESCRIPTION
+	To test help for the commands in a module, place this file in the module folder.
+	To test any module from any path, use https://github.com/juneb/PesterTDD/Module.Help.Tests.ps1
+#>
+
+<#
+.SYNOPSIS
+Gets command parameters; one per name. Prefers default parameter set.
+
+.DESCRIPTION
+Gets one CommandParameterInfo object for each parameter in the specified
+command. If a command has more than one parameter with the same name, this
+function gets the parameters in the default parameter set, if one is specified.
+
+For example, if a command has two parameter sets:
+	Name, ID  (default)
+	Name, Path
+This function returns:
+    Name (default), ID Path
+
+This function is used to get parameters for help and for help testing.
+
+.PARAMETER Command
+Enter a CommandInfo object, such as the object that Get-Command returns. You
+can also pipe a CommandInfo object to the function.
+
+This parameter takes a CommandInfo object, instead of a command name, so
+you can use the parameters of Get-Command to specify the module and version 
+of the command.
+
+.EXAMPLE
+PS C:\> Get-ParametersDefaultFirst -Command (Get-Command New-Guid)
+This command uses the Command parameter to specify the command to 
+Get-ParametersDefaultFirst
+
+.EXAMPLE
+PS C:\> Get-Command New-Guid | Get-ParametersDefaultFirst 
+You can also pipe a CommandInfo object to Get-ParametersDefaultFirst
+
+.EXAMPLE
+PS C:\> Get-ParametersDefaultFirst -Command (Get-Command BetterCredentials\Get-Credential)
+You can use the Command parameter to specify the CommandInfo object. This
+command runs Get-Command module-qualified name value.
+
+.EXAMPLE
+PS C:\> $ModuleSpec = @{ModuleName='BetterCredentials';RequiredVersion=4.3}
+PS C:\> Get-Command -FullyQualifiedName $ModuleSpec | Get-ParametersDefaultFirst
+This command uses a Microsoft.PowerShell.Commands.ModuleSpecification object to 
+specify the module and version. You can also use it to specify the module GUID.
+Then, it pipes the CommandInfo object to Get-ParametersDefaultFirst.
+#>
+function Get-ParametersDefaultFirst {
+	param (
+		[Parameter(Mandatory = $true,
+				   ValueFromPipeline = $true)]
+		[System.Management.Automation.CommandInfo]
+		$Command
+	)
+	
+	BEGIN {
+		$Common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'Whatif', 'Confirm'
+		$parameters = @()
+	}
+
+	PROCESS {
+		if ($defaultPSetName = $Command.DefaultParameterSet) {
+			$defaultParameters = ($Command.ParameterSets | Where-Object Name -eq $defaultPSetName).parameters | Where-Object Name -NotIn $Common
+			$otherParameters = ($Command.ParameterSets | Where-Object Name -ne $defaultPSetName).parameters | Where-Object Name -NotIn $Common
+			
+			$parameters += $defaultParameters
+			if ($parameters -and $otherParameters) {
+				$otherParameters | ForEach-Object {
+
+					if ($_.Name -notin $parameters.Name) {
+						$parameters += $_
+					}
+				}
+
+				$parameters = $parameters | Sort-Object Name
+			}
+		}
+
+		else {
+			$parameters = $Command.ParameterSets.Parameters | Where-Object Name -NotIn $Common | Sort-Object Name -Unique
+		}
+		
+		return $parameters
+	}
+
+	END { }
+}
+
+. $PSScriptRoot\Shared.ps1
+$ModuleBase = Split-Path -Parent $PSScriptRoot
+
+if ((Split-Path $ModuleBase -Leaf) -eq 'src') {
+	$ModuleBase = Split-Path $ModuleBase -Parent
+}
+
+$ModuleName = Split-Path $ModuleBase -Leaf
+$commands = Get-Command -Module $ModuleName -CommandType Cmdlet, Function, Workflow  # Not alias
+
+## When testing help, remember that help is cached at the beginning of each session.
+## To test, restart session.
+foreach ($command in $commands) {
+	$commandName = $command.Name
+	
+	# The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
+	$Help = Get-Help $ModuleName\$commandName -ErrorAction SilentlyContinue
+	
+	Describe "Test help for $commandName" {
+		# If help is not found, synopsis in auto-generated help is the syntax diagram
+		It "should not be auto-generated" {
+			$Help.Synopsis | Should Not BeLike '*`[`<CommonParameters`>`]*'
+		}
+		
+		# Should be a synopsis for every function
+		It "gets synopsis for $commandName" {
+			$Help.Synopsis | Should Not beNullOrEmpty
+		}
+		
+		# Should be a description for every function
+		It "gets description for $commandName" {
+			$Help.Description | Should Not BeNullOrEmpty
+		}
+		
+		# Should be at least one example
+		It "gets example code from $commandName" {
+			($Help.Examples.Example | Select-Object -First 1).Code | Should Not BeNullOrEmpty
+		}
+		
+		# Should be at least one example description
+		It "gets example help from $commandName" {
+			($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should Not BeNullOrEmpty
+		}
+		
+		Context "Test parameter help for $commandName" {
+			# Define ShouldProcess parameters for exclusion (It's pretty straightforward what these switches ought to do!).
+			$ShouldProcessParameters = 'WhatIf', 'Confirm'
+
+			# Get parameters. When >1 parameter with same name, 
+			# get parameter from the default parameter set, if any.
+			$parameters = Get-ParametersDefaultFirst -Command $command
+			$parameterNames = $parameters.Name  | Where-Object { $_ -notin $ShouldProcessParameters }
+			$HelpParameterNames = $Help.Parameters.Parameter.Name | Where-Object { $_ -notin $ShouldProcessParameters } | Sort-Object -Unique
+			
+			foreach ($parameter in $parameters) {
+				$parameterName = $parameter.Name
+				$parameterHelp = $Help.parameters.parameter | Where-Object Name -EQ $parameterName
+				
+				# Should be a description for every parameter
+				It "gets help for parameter: $parameterName : in $commandName" {
+					$parameterHelp.Description.Text | Should Not BeNullOrEmpty
+				}
+				
+				# Required value in Help should match IsMandatory property of parameter
+				It "help for $parameterName parameter in $commandName has correct Mandatory value" {
+					$codeMandatory = $parameter.IsMandatory.toString()
+					$parameterHelp.Required | Should Be $codeMandatory
+				}
+				
+				# Parameter type in Help should match code
+				It "help for $commandName has correct parameter type for $parameterName" {
+					$codeType = $parameter.ParameterType.Name
+					# To avoid calling Trim method on a null object.
+					$helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
+					$helpType | Should be $codeType
+				}
+			}
+			
+			foreach ($helpParm in $HelpParameterNames) {
+				# Shouldn't find extra parameters in help.
+				It "finds help parameter in code: $helpParm" {
+					$helpParm -in $parameterNames | Should Be $true
+				}
+			}
+		}
+	}
+}

--- a/examples/NewModuleTemplate/Tests/Module.T.ps1
+++ b/examples/NewModuleTemplate/Tests/Module.T.ps1
@@ -1,6 +1,4 @@
-$ModuleManifestName = '<%=$PLASTER_PARAM_ModuleName%>.psd1'
-# <%=${PLASTER_GUID1}%> - testing use of PLASTER predefined variables.
-Import-Module $PSScriptRoot\..\src\$ModuleManifestName
+. $PSScriptRoot\Shared.ps1
 
 Describe 'Module Manifest Tests' {
     It 'Passes Test-ModuleManifest' {

--- a/examples/NewModuleTemplate/Tests/Shared.ps1
+++ b/examples/NewModuleTemplate/Tests/Shared.ps1
@@ -1,0 +1,6 @@
+$ModuleManifestName = '<%=$PLASTER_PARAM_ModuleName%>.psd1'
+$ModulePath         = "$PSScriptRoot\..\src\$ModuleManifestName"
+
+# -Scope Global is needed when running tests from inside of psake, otherwise
+# the module's functions cannot be found in the Plaster\ namespace
+Import-Module $ModulePath -Scope Global

--- a/examples/NewModuleTemplate/plasterManifest.xml
+++ b/examples/NewModuleTemplate/plasterManifest.xml
@@ -93,8 +93,14 @@ Scaffold a PowerShell Module with the files required to run Pester tests, build 
                       condition="$PLASTER_PARAM_License -eq 'MIT'"/>
         <templateFile source='en-US\about_Module.help.txt'
                       destination='en-US\about_${PLASTER_PARAM_ModuleName}.help.txt'/>
+        <templateFile source='Tests\Help.Tests.ps1'
+                      destination='test\ModuleHelp.Tests.ps1'
+                      condition="$PLASTER_PARAM_Options -contains 'Pester'"/>
         <templateFile source='Tests\Module.T.ps1'
                       destination='test\${PLASTER_PARAM_ModuleName}.Tests.ps1'
+                      condition="$PLASTER_PARAM_Options -contains 'Pester'"/>
+        <templateFile source='Tests\Shared.ps1'
+                      destination='test\Shared.ps1'
                       condition="$PLASTER_PARAM_Options -contains 'Pester'"/>
         <templateFile source='RecurseTemplateFile\**'
                       destination='Recurse'

--- a/test/Help.Tests.ps1
+++ b/test/Help.Tests.ps1
@@ -1,0 +1,187 @@
+<#	
+	.NOTES
+		===========================================================================
+		Created with: 	SAPIEN Technologies, Inc., PowerShell Studio 2016 v5.2.119
+		Created on:   	4/12/2016 1:11 PM
+		Created by:   	June Blender
+		Organization: 	SAPIEN Technologies, Inc
+		Filename:		*.Help.Tests.ps1
+		===========================================================================
+	.DESCRIPTION
+	To test help for the commands in a module, place this file in the module folder.
+	To test any module from any path, use https://github.com/juneb/PesterTDD/Module.Help.Tests.ps1
+#>
+
+<#
+.SYNOPSIS
+Gets command parameters; one per name. Prefers default parameter set.
+
+.DESCRIPTION
+Gets one CommandParameterInfo object for each parameter in the specified
+command. If a command has more than one parameter with the same name, this
+function gets the parameters in the default parameter set, if one is specified.
+
+For example, if a command has two parameter sets:
+	Name, ID  (default)
+	Name, Path
+This function returns:
+    Name (default), ID Path
+
+This function is used to get parameters for help and for help testing.
+
+.PARAMETER Command
+Enter a CommandInfo object, such as the object that Get-Command returns. You
+can also pipe a CommandInfo object to the function.
+
+This parameter takes a CommandInfo object, instead of a command name, so
+you can use the parameters of Get-Command to specify the module and version 
+of the command.
+
+.EXAMPLE
+PS C:\> Get-ParametersDefaultFirst -Command (Get-Command New-Guid)
+This command uses the Command parameter to specify the command to 
+Get-ParametersDefaultFirst
+
+.EXAMPLE
+PS C:\> Get-Command New-Guid | Get-ParametersDefaultFirst 
+You can also pipe a CommandInfo object to Get-ParametersDefaultFirst
+
+.EXAMPLE
+PS C:\> Get-ParametersDefaultFirst -Command (Get-Command BetterCredentials\Get-Credential)
+You can use the Command parameter to specify the CommandInfo object. This
+command runs Get-Command module-qualified name value.
+
+.EXAMPLE
+PS C:\> $ModuleSpec = @{ModuleName='BetterCredentials';RequiredVersion=4.3}
+PS C:\> Get-Command -FullyQualifiedName $ModuleSpec | Get-ParametersDefaultFirst
+This command uses a Microsoft.PowerShell.Commands.ModuleSpecification object to 
+specify the module and version. You can also use it to specify the module GUID.
+Then, it pipes the CommandInfo object to Get-ParametersDefaultFirst.
+#>
+function Get-ParametersDefaultFirst {
+	param (
+		[Parameter(Mandatory = $true,
+				   ValueFromPipeline = $true)]
+		[System.Management.Automation.CommandInfo]
+		$Command
+	)
+	
+	BEGIN {
+		$Common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'Whatif', 'Confirm'
+		$parameters = @()
+	}
+
+	PROCESS {
+		if ($defaultPSetName = $Command.DefaultParameterSet) {
+			$defaultParameters = ($Command.ParameterSets | Where-Object Name -eq $defaultPSetName).parameters | Where-Object Name -NotIn $Common
+			$otherParameters = ($Command.ParameterSets | Where-Object Name -ne $defaultPSetName).parameters | Where-Object Name -NotIn $Common
+			
+			$parameters += $defaultParameters
+			if ($parameters -and $otherParameters) {
+				$otherParameters | ForEach-Object {
+
+					if ($_.Name -notin $parameters.Name) {
+						$parameters += $_
+					}
+				}
+
+				$parameters = $parameters | Sort-Object Name
+			}
+		}
+
+		else {
+			$parameters = $Command.ParameterSets.Parameters | Where-Object Name -NotIn $Common | Sort-Object Name -Unique
+		}
+		
+		return $parameters
+	}
+
+	END { }
+}
+
+. $PSScriptRoot\Shared.ps1
+
+if ((Split-Path $ModuleBase -Leaf) -eq 'src') {
+	$ModuleBase = Split-Path $ModuleBase -Parent
+}
+
+$ModuleName = Split-Path $ModuleBase -Leaf
+$commands = Get-Command -Module $ModuleName -CommandType Cmdlet, Function, Workflow  # Not alias
+
+## When testing help, remember that help is cached at the beginning of each session.
+## To test, restart session.
+foreach ($command in $commands) {
+	$commandName = $command.Name
+	
+	# The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
+	$Help = Get-Help $ModuleName\$commandName -ErrorAction SilentlyContinue
+	
+	Describe "Test help for $commandName" {
+		# If help is not found, synopsis in auto-generated help is the syntax diagram
+		It "should not be auto-generated" {
+			$Help.Synopsis | Should Not BeLike '*`[`<CommonParameters`>`]*'
+		}
+		
+		# Should be a synopsis for every function
+		It "gets synopsis for $commandName" {
+			$Help.Synopsis | Should Not beNullOrEmpty
+		}
+		
+		# Should be a description for every function
+		It "gets description for $commandName" {
+			$Help.Description | Should Not BeNullOrEmpty
+		}
+		
+		# Should be at least one example
+		It "gets example code from $commandName" {
+			($Help.Examples.Example | Select-Object -First 1).Code | Should Not BeNullOrEmpty
+		}
+		
+		# Should be at least one example description
+		It "gets example help from $commandName" {
+			($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should Not BeNullOrEmpty
+		}
+		
+		Context "Test parameter help for $commandName" {
+			# Define ShouldProcess parameters for exclusion (It's pretty straightforward what these switches ought to do!).
+			$ShouldProcessParameters = 'WhatIf', 'Confirm'
+
+			# Get parameters. When >1 parameter with same name, 
+			# get parameter from the default parameter set, if any.
+			$parameters = Get-ParametersDefaultFirst -Command $command
+			$parameterNames = $parameters.Name  | Where-Object { $_ -notin $ShouldProcessParameters }
+			$HelpParameterNames = $Help.Parameters.Parameter.Name | Where-Object { $_ -notin $ShouldProcessParameters } | Sort-Object -Unique
+			
+			foreach ($parameter in $parameters) {
+				$parameterName = $parameter.Name
+				$parameterHelp = $Help.parameters.parameter | Where-Object Name -EQ $parameterName
+				
+				# Should be a description for every parameter
+				It "gets help for parameter: $parameterName : in $commandName" {
+					$parameterHelp.Description.Text | Should Not BeNullOrEmpty
+				}
+				
+				# Required value in Help should match IsMandatory property of parameter
+				It "help for $parameterName parameter in $commandName has correct Mandatory value" {
+					$codeMandatory = $parameter.IsMandatory.toString()
+					$parameterHelp.Required | Should Be $codeMandatory
+				}
+				
+				# Parameter type in Help should match code
+				It "help for $commandName has correct parameter type for $parameterName" {
+					$codeType = $parameter.ParameterType.Name
+					# To avoid calling Trim method on a null object.
+					$helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
+					$helpType | Should be $codeType
+				}
+			}
+			
+			foreach ($helpParm in $HelpParameterNames) {
+				# Shouldn't find extra parameters in help.
+				It "finds help parameter in code: $helpParm" {
+					$helpParm -in $parameterNames | Should Be $true
+				}
+			}
+		}
+	}
+}

--- a/test/Help.Tests.ps1
+++ b/test/Help.Tests.ps1
@@ -100,6 +100,7 @@ function Get-ParametersDefaultFirst {
 }
 
 . $PSScriptRoot\Shared.ps1
+$ModuleBase = Split-Path -Parent $PSScriptRoot
 
 if ((Split-Path $ModuleBase -Leaf) -eq 'src') {
 	$ModuleBase = Split-Path $ModuleBase -Parent


### PR DESCRIPTION
Add module help tests to the plaster module, as well as the NewModuleTemplate.

The help tests themselves come from @juneb, with a couple of edits to fit. The tests are pretty awesome at covering all the standard help cases for modules and I thought they would be a good fit for what plaster is trying to achieve by enforcing good practice through the testing framework.

I know the plan is to remove the current module template, I used it for testing the slightly different test file structure to make sure it all worked as expected once the template was deployed. The test additions could easily be merged into the official template once we're happy with it.