### PR TITLE
Comment out all settings in NewModule SA settings.

### DIFF
--- a/ScriptAnalyzerSettings.psd1
+++ b/ScriptAnalyzerSettings.psd1
@@ -17,12 +17,18 @@
     # Use ExcludeRules when you want to run most of the default set of rules except
     # for a few rules you wish to "exclude".  Note: if a rule is in both IncludeRules
     # and ExcludeRules, the rule will be excluded.
-    ExcludeRules = @('PSAvoidUsingWriteHost')
+    ExcludeRules = @('PSAvoidUsingWriteHost','PSMissingModuleManifestField')
+
 
     # You can use the following entry to supply parameters to rules that take parameters.
     # For instance, the PSAvoidUsingCmdletAliases rule takes a whitelist for aliases you
     # want to allow.
     #Rules = @{
+    #    Do not flag 'cd' alias.
     #    PSAvoidUsingCmdletAliases = @{Whitelist = @('cd')}
+
+    #    Check if your script uses cmdlets that are compatible on PowerShell Core,
+    #    version 6.0.0-alpha, on Linux.
+    #    PSUseCompatibleCmdlets = @{Compatibility = @("core-6.0.0-alpha-linux")}
     #}
 }

--- a/src/Templates/NewModule/ScriptAnalyzerSettings.psd1
+++ b/src/Templates/NewModule/ScriptAnalyzerSettings.psd1
@@ -17,7 +17,7 @@
     # Use ExcludeRules when you want to run most of the default set of rules except
     # for a few rules you wish to "exclude".  Note: if a rule is in both IncludeRules
     # and ExcludeRules, the rule will be excluded.
-    ExcludeRules = @('PSAvoidUsingWriteHost')
+    #ExcludeRules = @('PSAvoidUsingWriteHost')
 
     # You can use the following entry to supply parameters to rules that take parameters.
     # For instance, the PSAvoidUsingCmdletAliases rule takes a whitelist for aliases you
@@ -26,8 +26,8 @@
     #    Do not flag 'cd' alias.
     #    PSAvoidUsingCmdletAliases = @{Whitelist = @('cd')}
 
-    #   Check if your script uses cmdlets that are compatible on PowerShell Core,
-    #   version 6.0.0-alpha, on Linux.
-    #   PSUseCompatibleCmdlets = @{Compatibility = @("core-6.0.0-alpha-linux")}
+    #    Check if your script uses cmdlets that are compatible on PowerShell Core,
+    #    version 6.0.0-alpha, on Linux.
+    #    PSUseCompatibleCmdlets = @{Compatibility = @("core-6.0.0-alpha-linux")}
     #}
 }


### PR DESCRIPTION
Adjust Plaster PSSA settings file to exclude the PSMissingModuleManifestField rule. We have a Pester test to verify the plaster module manifest.