### PR TITLE
Enhancements to the Sign build task.

### DIFF
--- a/build.settings.ps1
+++ b/build.settings.ps1
@@ -76,6 +76,9 @@ Properties {
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '', Scope='*', Target='CertSubjectName')]
     $CertSubjectName = $null
 
+    # Certificate store path
+    $CertPath = "Cert:\"
+
     # -------------------- Publishing properties ------------------------------
 
     # Your NuGet API key for the PSGallery.  Leave it as $null and the first time you publish,
@@ -92,7 +95,6 @@ Properties {
     # The contents of this file are used during publishing for the ReleaseNotes parameter.
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '', Scope='*', Target='ReleaseNotesPath')]
     $ReleaseNotesPath = "$PSScriptRoot\ReleaseNotes.md"
-
 
     # ----------------------- Misc properties ---------------------------------
 

--- a/src/Templates/NewModule/build.settings.ps1
+++ b/src/Templates/NewModule/build.settings.ps1
@@ -76,6 +76,9 @@ Properties {
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '', Scope='*', Target='CertSubjectName')]
     $CertSubjectName = $null
 
+    # Certificate store path
+    $CertPath = "Cert:\"
+
     # -------------------- Publishing properties ------------------------------
 
     # Your NuGet API key for the PSGallery.  Leave it as $null and the first time you publish,
@@ -92,7 +95,6 @@ Properties {
     # The contents of this file are used during publishing for the ReleaseNotes parameter.
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '', Scope='*', Target='ReleaseNotesPath')]
     $ReleaseNotesPath = "$PSScriptRoot\ReleaseNotes.md"
-
 
     # ----------------------- Misc properties ---------------------------------
 


### PR DESCRIPTION
Introduced a new variable - $CertPath which defaults to cert:\.  Also made the sign task act more like signtool /n where you can specify a "substring" of the subject name but the case has to match.  Also added warning to tell user when they had no code-signing certs installed and what to do.  Also added warning when the specified CertSubjectName certificate has expired.

Also, when first running sign and the user hasn't specified a cert subject name, we dump a list of valid, code-signing certs for them to choose from.