### PR TITLE
Allows templates to be placed under Source Control.

### DIFF
--- a/src/Templates/.gitignore
+++ b/src/Templates/.gitignore
@@ -1,0 +1,4 @@
+*
+*/
+!.gitignore
+!NewModule


### PR DESCRIPTION
This change will cause git to ignore everything in the Templates directory except for the NewModule folder. The reason for this change is to allow users to place their own templates in the Templates directory and have those templates under their own source control repository.  New folders can be placed in the repository and added to .gitignore to be included.