### PR TITLE
Lots of NewModule template cleanup.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -39,7 +39,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Clean ...'; Invoke-psake build.psake.ps1 -taskList Clean;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Clean'; Invoke-psake build.psake.ps1 -taskList Clean;",
                 "Invoke-Command { Write-Host 'Completed Clean task in task runner.' }"
             ]
         },
@@ -49,7 +49,7 @@
             "isBuildCommand": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Build ...'; Invoke-psake build.psake.ps1 -taskList Build;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Build'; Invoke-psake build.psake.ps1 -taskList Build;",
                 "Invoke-Command { Write-Host 'Completed Build task in task runner.' }"
             ]
         },
@@ -58,7 +58,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake -taskList BuildHelp ...'; Invoke-psake build.psake.ps1 -taskList BuildHelp;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList BuildHelp'; Invoke-psake build.psake.ps1 -taskList BuildHelp;",
                 "Invoke-Command { Write-Host 'Completed BuildHelp task in task runner.' }"
             ]
         },
@@ -67,7 +67,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Analyze ...'; Invoke-psake build.psake.ps1 -taskList Analyze;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Analyze'; Invoke-psake build.psake.ps1 -taskList Analyze;",
                 "Invoke-Command { Write-Host 'Completed Analyze task in task runner.' }"
             ]
         },
@@ -76,7 +76,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Install ...'; Invoke-psake build.psake.ps1 -taskList Install;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Install'; Invoke-psake build.psake.ps1 -taskList Install;",
                 "Invoke-Command { Write-Host 'Completed Install task in task runner.' }"
             ]
         },
@@ -85,7 +85,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Publish ...'; Invoke-psake build.psake.ps1 -taskList Publish;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Publish'; Invoke-psake build.psake.ps1 -taskList Publish;",
                 "Invoke-Command { Write-Host 'Completed Publish task in task runner.' }"
             ]
         },
@@ -95,7 +95,7 @@
             "isTestCommand": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking Pester...'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
+                "Write-Host 'Invoking Pester'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
                 "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
             ],
             "problemMatcher": [

--- a/build.psake.ps1
+++ b/build.psake.ps1
@@ -246,6 +246,7 @@ Task InstallImpl -depends BuildHelp, PreInstall -requiredVariables OutDir {
     }
 
     Copy-Item -Path $OutDir\* -Destination $InstallPath -Verbose:$VerbosePreference -Recurse -Force
+    "Module installed into $InstallPath"
 }
 
 Task Test -depends Analyze -requiredVariables TestRootDir, ModuleName {

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -29,13 +29,13 @@ function Invoke-Plaster {
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
         # Specifies the path to either the Template directory or a ZIP file containing the template.
-        [Parameter(Mandatory = $true)]
+        [Parameter(Position = 0, Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $TemplatePath,
 
         # Specifies the path to directory in which the template will use as a root directory when generating files.
-        [Parameter(Mandatory = $true)]
+        [Parameter(Position = 1, Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $DestinationPath,

--- a/src/Templates/NewModule/build.psake.ps1
+++ b/src/Templates/NewModule/build.psake.ps1
@@ -246,6 +246,7 @@ Task InstallImpl -depends BuildHelp, PreInstall -requiredVariables OutDir {
     }
 
     Copy-Item -Path $OutDir\* -Destination $InstallPath -Verbose:$VerbosePreference -Recurse -Force
+    "Module installed into $InstallPath"
 }
 
 Task Test -depends Analyze -requiredVariables TestRootDir, ModuleName {

--- a/src/Templates/NewModule/editor/VSCode/tasks_pester.json
+++ b/src/Templates/NewModule/editor/VSCode/tasks_pester.json
@@ -1,0 +1,66 @@
+// Available variables which can be used inside of strings.
+// ${workspaceRoot}: the root folder of the team
+// ${file}: the current opened file
+// ${relativeFile}: the current opened file relative to workspaceRoot
+// ${fileBasename}: the current opened file's basename
+// ${fileDirname}: the current opened file's dirname
+// ${fileExtname}: the current opened file's extension
+// ${cwd}: the current working directory of the spawned process
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+	"version": "0.1.0",
+
+	// Start PowerShell
+    "windows": {
+        "command": "${env.windir}\\sysnative\\windowspowershell\\v1.0\\PowerShell.exe"
+    },
+    "linux": {
+        "command": "/usr/bin/powershell"
+    },
+    "osx": {
+        "command": "/usr/local/bin/powershell"
+    },
+
+	// The command is a shell script
+	"isShellCommand": true,
+
+	// Show the output window always
+	"showOutput": "always",
+
+    "args": [
+        "-NoProfile", "-ExecutionPolicy", "Bypass"
+    ],
+
+    // Associate with test task runner
+    "tasks": [
+        {
+            "taskName": "Test",
+            "suppressTaskName": true,
+            "isTestCommand": true,
+            "showOutput": "always",
+            "args": [
+                "Write-Host 'Invoking Pester'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
+                "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
+            ],
+            "problemMatcher": [
+                {
+                    "owner": "powershell",
+                    "fileLocation": ["absolute"],
+                    "severity": "error",
+                    "pattern": [
+                        {
+                            "regexp": "^\\s*(\\[-\\]\\s*.*?)(\\d+)ms\\s*$",
+                            "message": 1
+                        },
+                        {
+                            "regexp": "^\\s+at\\s+[^,]+,\\s*(.*?):\\s+line\\s+(\\d+)$",
+                            "file": 1,
+                            "line": 2
+                        }
+                    ]
+                }
+            ]
+        }
+	]
+}

--- a/src/Templates/NewModule/editor/VSCode/tasks_psake.json
+++ b/src/Templates/NewModule/editor/VSCode/tasks_psake.json
@@ -88,34 +88,6 @@
                 "Write-Host 'Invoking psake build.psake.ps1 -taskList Publish ...'; Invoke-psake build.psake.ps1 -taskList Publish;",
                 "Invoke-Command { Write-Host 'Completed Publish task in task runner.' }"
             ]
-        },
-        {
-            "taskName": "Test",
-            "suppressTaskName": true,
-            "isTestCommand": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking Pester...'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
-                "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
-            ],
-            "problemMatcher": [
-                {
-                    "owner": "powershell",
-                    "fileLocation": ["absolute"],
-                    "severity": "error",
-                    "pattern": [
-                        {
-                            "regexp": "^\\s*(\\[-\\]\\s*.*?)(\\d+)ms\\s*$",
-                            "message": 1
-                        },
-                        {
-                            "regexp": "^\\s+at\\s+[^,]+,\\s*(.*?):\\s+line\\s+(\\d+)$",
-                            "file": 1,
-                            "line": 2
-                        }
-                    ]
-                }
-            ]
         }
 	]
 }

--- a/src/Templates/NewModule/editor/VSCode/tasks_psake.json
+++ b/src/Templates/NewModule/editor/VSCode/tasks_psake.json
@@ -39,7 +39,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Clean ...'; Invoke-psake build.psake.ps1 -taskList Clean;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Clean'; Invoke-psake build.psake.ps1 -taskList Clean;",
                 "Invoke-Command { Write-Host 'Completed Clean task in task runner.' }"
             ]
         },
@@ -49,7 +49,7 @@
             "isBuildCommand": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Build ...'; Invoke-psake build.psake.ps1 -taskList Build;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Build'; Invoke-psake build.psake.ps1 -taskList Build;",
                 "Invoke-Command { Write-Host 'Completed Build task in task runner.' }"
             ]
         },
@@ -58,7 +58,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake -taskList BuildHelp ...'; Invoke-psake build.psake.ps1 -taskList BuildHelp;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList BuildHelp'; Invoke-psake build.psake.ps1 -taskList BuildHelp;",
                 "Invoke-Command { Write-Host 'Completed BuildHelp task in task runner.' }"
             ]
         },
@@ -67,7 +67,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Analyze ...'; Invoke-psake build.psake.ps1 -taskList Analyze;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Analyze'; Invoke-psake build.psake.ps1 -taskList Analyze;",
                 "Invoke-Command { Write-Host 'Completed Analyze task in task runner.' }"
             ]
         },
@@ -76,7 +76,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Install ...'; Invoke-psake build.psake.ps1 -taskList Install;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Install'; Invoke-psake build.psake.ps1 -taskList Install;",
                 "Invoke-Command { Write-Host 'Completed Install task in task runner.' }"
             ]
         },
@@ -85,7 +85,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Publish ...'; Invoke-psake build.psake.ps1 -taskList Publish;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Publish'; Invoke-psake build.psake.ps1 -taskList Publish;",
                 "Invoke-Command { Write-Host 'Completed Publish task in task runner.' }"
             ]
         }

--- a/src/Templates/NewModule/editor/VSCode/tasks_psake_pester.json
+++ b/src/Templates/NewModule/editor/VSCode/tasks_psake_pester.json
@@ -39,7 +39,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Clean ...'; Invoke-psake build.psake.ps1 -taskList Clean;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Clean'; Invoke-psake build.psake.ps1 -taskList Clean;",
                 "Invoke-Command { Write-Host 'Completed Clean task in task runner.' }"
             ]
         },
@@ -49,7 +49,7 @@
             "isBuildCommand": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Build ...'; Invoke-psake build.psake.ps1 -taskList Build;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Build'; Invoke-psake build.psake.ps1 -taskList Build;",
                 "Invoke-Command { Write-Host 'Completed Build task in task runner.' }"
             ]
         },
@@ -58,7 +58,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake -taskList BuildHelp ...'; Invoke-psake build.psake.ps1 -taskList BuildHelp;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList BuildHelp'; Invoke-psake build.psake.ps1 -taskList BuildHelp;",
                 "Invoke-Command { Write-Host 'Completed BuildHelp task in task runner.' }"
             ]
         },
@@ -67,7 +67,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Analyze ...'; Invoke-psake build.psake.ps1 -taskList Analyze;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Analyze'; Invoke-psake build.psake.ps1 -taskList Analyze;",
                 "Invoke-Command { Write-Host 'Completed Analyze task in task runner.' }"
             ]
         },
@@ -76,7 +76,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Install ...'; Invoke-psake build.psake.ps1 -taskList Install;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Install'; Invoke-psake build.psake.ps1 -taskList Install;",
                 "Invoke-Command { Write-Host 'Completed Install task in task runner.' }"
             ]
         },
@@ -85,7 +85,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake build.psake.ps1 -taskList Publish ...'; Invoke-psake build.psake.ps1 -taskList Publish;",
+                "Write-Host 'Invoking psake on build.psake.ps1 -taskList Publish'; Invoke-psake build.psake.ps1 -taskList Publish;",
                 "Invoke-Command { Write-Host 'Completed Publish task in task runner.' }"
             ]
         },
@@ -95,7 +95,7 @@
             "isTestCommand": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking Pester...'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
+                "Write-Host 'Invoking Pester'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
                 "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
             ],
             "problemMatcher": [

--- a/src/Templates/NewModule/editor/VSCode/tasks_psake_pester.json
+++ b/src/Templates/NewModule/editor/VSCode/tasks_psake_pester.json
@@ -1,15 +1,26 @@
 // Available variables which can be used inside of strings.
 // ${workspaceRoot}: the root folder of the team
 // ${file}: the current opened file
+// ${relativeFile}: the current opened file relative to workspaceRoot
 // ${fileBasename}: the current opened file's basename
 // ${fileDirname}: the current opened file's dirname
 // ${fileExtname}: the current opened file's extension
 // ${cwd}: the current working directory of the spawned process
 {
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
 	"version": "0.1.0",
 
 	// Start PowerShell
-	"command": "${env.windir}\\sysnative\\windowspowershell\\v1.0\\PowerShell.exe",
+    "windows": {
+        "command": "${env.windir}\\sysnative\\windowspowershell\\v1.0\\PowerShell.exe"
+    },
+    "linux": {
+        "command": "/usr/bin/powershell"
+    },
+    "osx": {
+        "command": "/usr/local/bin/powershell"
+    },
 
 	// The command is a shell script
 	"isShellCommand": true,
@@ -28,7 +39,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake...'; Invoke-psake build.psake.ps1 -taskList Clean;",
+                "Write-Host 'Invoking psake build.psake.ps1 -taskList Clean ...'; Invoke-psake build.psake.ps1 -taskList Clean;",
                 "Invoke-Command { Write-Host 'Completed Clean task in task runner.' }"
             ]
         },
@@ -38,7 +49,7 @@
             "isBuildCommand": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake...'; Invoke-psake build.psake.ps1 -taskList Build;",
+                "Write-Host 'Invoking psake build.psake.ps1 -taskList Build ...'; Invoke-psake build.psake.ps1 -taskList Build;",
                 "Invoke-Command { Write-Host 'Completed Build task in task runner.' }"
             ]
         },
@@ -47,7 +58,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake...'; Invoke-psake build.psake.ps1 -taskList BuildHelp;",
+                "Write-Host 'Invoking psake -taskList BuildHelp ...'; Invoke-psake build.psake.ps1 -taskList BuildHelp;",
                 "Invoke-Command { Write-Host 'Completed BuildHelp task in task runner.' }"
             ]
         },
@@ -56,7 +67,7 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake...'; Invoke-psake build.psake.ps1 -taskList Analyze;",
+                "Write-Host 'Invoking psake build.psake.ps1 -taskList Analyze ...'; Invoke-psake build.psake.ps1 -taskList Analyze;",
                 "Invoke-Command { Write-Host 'Completed Analyze task in task runner.' }"
             ]
         },
@@ -65,8 +76,17 @@
             "suppressTaskName": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking psake...'; Invoke-psake build.psake.ps1 -taskList Install;",
+                "Write-Host 'Invoking psake build.psake.ps1 -taskList Install ...'; Invoke-psake build.psake.ps1 -taskList Install;",
                 "Invoke-Command { Write-Host 'Completed Install task in task runner.' }"
+            ]
+        },
+        {
+            "taskName": "Publish",
+            "suppressTaskName": true,
+            "showOutput": "always",
+            "args": [
+                "Write-Host 'Invoking psake build.psake.ps1 -taskList Publish ...'; Invoke-psake build.psake.ps1 -taskList Publish;",
+                "Invoke-Command { Write-Host 'Completed Publish task in task runner.' }"
             ]
         },
         {
@@ -96,15 +116,6 @@
                     ]
                 }
             ]
-        },
-        {
-            "taskName": "Publish",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake...'; Invoke-psake build.psake.ps1 -taskList Publish;",
-                "Invoke-Command { Write-Host 'Completed Publish task in task runner.' }"
-            ]
         }
-    ]
+	]
 }

--- a/src/Templates/NewModule/plasterManifest.xml
+++ b/src/Templates/NewModule/plasterManifest.xml
@@ -31,66 +31,60 @@
         <parameter name='License'
                    type='choice'
                    prompt='Select a license (see http://choosealicense.com for help choosing):'
-                   default='2'
+                   default='0'
                    store='text'>
+            <choice label='&amp;None'
+                    help="No license."
+                    value="None"/>
             <choice label='&amp;Apache'
                     help="Adds an Apache license file."
                     value="Apache"/>
             <choice label='&amp;MIT'
                     help="Adds an MIT license file."
                     value="MIT"/>
-            <choice label='&amp;None'
-                    help="No license."
-                    value="None"/>
         </parameter>
 
         <parameter name='Options'
                    type='multichoice'
                    prompt='Select one or more of the following tooling options:'
-                   default='0,1,2,3'
+                   default='1,2,3,4'
                    store='text' >
-            <choice label='&amp;Git .gitignore file'
+            <choice label='&amp;None'
+                    help="No tooling options specified."
+                    value="None"/>
+            <choice label='Add &amp;Git .gitignore file'
                     help="Adds a .gitignore file."
                     value="Git"/>
-            <choice label='p&amp;sake build script'
+            <choice label='Add p&amp;sake build script'
                     help="Adds psake build script that generates the module directory for publishing to the PowerShell Gallery."
                     value="psake"/>
-            <choice label='&amp;Pester test support'
+            <choice label='Add &amp;Pester test support'
                     help="Adds test directory and Pester test for the module manifest file."
                     value="Pester"/>
-            <choice label='PSScript&amp;Analyzer'
+            <choice label='Add PSScript&amp;Analyzer support'
                     help="Adds script analysis support using PSScriptAnalyzer."
                     value="PSScriptAnalyzer"/>
-            <choice label='plat&amp;yPS help generator'
+            <choice label='Add plat&amp;yPS help generation support'
                     help="Adds help build support using platyPS."
                     value="platyPS"/>
-            <choice label='&amp;None'
-                    help="No options specified."
-                    value="None"/>
         </parameter>
 
         <parameter name='Editor'
                    type='choice'
-                   prompt='Which script editor do you use?'
-                   default='2'
+                   prompt='Select one of the supported script editors for better editor integration (or None):'
+                   default='0'
                    store='text' >
-            <choice label='&amp;ISE'
-                    help="Your editor is PowerShell ISE."
-                    value="ISE"/>
-            <choice label='Visual Studio &amp;Code'
-                    help="Your editor is Visual Studio Code."
-                    value="VSCode"/>
             <choice label='&amp;None'
                     help="No editor specified."
                     value="None"/>
+            <choice label='Visual Studio &amp;Code'
+                    help="Your editor is Visual Studio Code."
+                    value="VSCode"/>
         </parameter>
     </parameters>
 
     <content>
-        <message>
-Scaffold a PowerShell Module with the files required to run Pester tests, build with psake and publish to the PSGallery.
-
-        </message>
+        <message>&#10;&#10;Scaffolding your PowerShell Module...&#10;&#10;&#10;</message>
 
         <newModuleManifest destination='src\${PLASTER_PARAM_ModuleName}.psd1'
                            moduleVersion='$PLASTER_PARAM_Version'
@@ -98,12 +92,13 @@ Scaffold a PowerShell Module with the files required to run Pester tests, build 
                            author='$PLASTER_PARAM_FullName'
                            description='$PLASTER_PARAM_ModuleDesc'
                            encoding='UTF8-NoBOM'/>
-        <file source='_gitignore'
-              destination='.gitignore'
-              condition='$PLASTER_PARAM_Options -contains "Git"'/>
-        <file source='build*.ps1'
-              destination=''
-              condition='$PLASTER_PARAM_Options -contains "psake"'/>
+
+        <file condition='$PLASTER_PARAM_Options -contains "Git"'
+              source='_gitignore'
+              destination='.gitignore' />
+        <file condition='$PLASTER_PARAM_Options -contains "psake"'
+              source='build*.ps1'
+              destination='' />
         <file source='ReleaseNotes.md'
               destination=''/>
         <file source='src\Module.psm1'
@@ -113,117 +108,29 @@ Scaffold a PowerShell Module with the files required to run Pester tests, build 
 
         <templateFile source='en-US\about_Module.help.txt'
                       destination='en-US\about_${PLASTER_PARAM_ModuleName}.help.txt'/>
-        <templateFile source='test\Module.T.ps1'
-                      destination='test\${PLASTER_PARAM_ModuleName}.Tests.ps1'
-                      condition="$PLASTER_PARAM_Options -contains 'Pester'"/>
-        <templateFile source='test\Shared.ps1'
-                      destination='test\Shared.ps1'
-                      condition="$PLASTER_PARAM_Options -contains 'Pester'"/>
-        <templateFile source='license\Apache.txt'
+        <templateFile condition="$PLASTER_PARAM_Options -contains 'Pester'"
+                      source='test\Module.T.ps1'
+                      destination='test\${PLASTER_PARAM_ModuleName}.Tests.ps1' />
+        <templateFile condition="$PLASTER_PARAM_Options -contains 'Pester'"
+                      source='test\Shared.ps1'
+                      destination='test\Shared.ps1' />
+        <templateFile condition="$PLASTER_PARAM_License -eq 'Apache'"
+                      source='license\Apache.txt'
                       destination='LICENSE.txt'
-                      condition="$PLASTER_PARAM_License -eq 'Apache'"
                       encoding="UTF8-NoBOM"/>
-        <templateFile source='license\MIT.txt'
-                      destination='LICENSE.txt'
-                      condition="$PLASTER_PARAM_License -eq 'MIT'"/>
+        <templateFile condition="$PLASTER_PARAM_License -eq 'MIT'"
+                      source='license\MIT.txt'
+                      destination='LICENSE.txt' />
 
-        <file source='editor\VSCode\*.json'
-              destination='.vscode'
-              condition="$PLASTER_PARAM_Editor -eq 'VSCode'"/>
-        <modify path='.vscode\tasks.json' encoding='UTF8'
-                condition="$PLASTER_PARAM_Editor -eq 'VSCode'">
-            <replace condition="$PLASTER_FileContent -notmatch '// Author:'">
-                <original>(?s)^(.*)</original>
-                <substitute expand='true'>// Author: $PLASTER_PARAM_FullName`r`n`$1</substitute>
-            </replace>
-            <replace condition="$PLASTER_PARAM_Options -contains 'Pester' -and $PLASTER_FileContent -notmatch 'taskName&quot;:\s*&quot;Test&quot;'">
-                <original><![CDATA[(?si)(?<="tasks":\s*\[)(\s*)(?=\{)]]></original>
-                <substitute><![CDATA[$1{
-            "taskName": "Test",
-            "suppressTaskName": true,
-            "isTestCommand": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking Pester...'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
-                "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
-            ],
-            "problemMatcher": [
-                {
-                    "owner": "powershell",
-                    "fileLocation": ["absolute"],
-                    "severity": "error",
-                    "pattern": [
-                        {
-                            "regexp": "^\\s*(\\[-\\]\\s*.*?)(\\d+)ms\\s*$",
-                            "message": 1
-                        },
-                        {
-                            "regexp": "^\\s+at\\s+[^,]+,\\s*(.*?):\\s+line\\s+(\\d+)$",
-                            "file": 1,
-                            "line": 2
-                        }
-                    ]
-                }
-            ]
-        },$1]]></substitute>
-            </replace>
+        <file condition="($PLASTER_PARAM_Editor -eq 'VSCode') -and ($PLASTER_PARAM_Options -contains 'psake') -and ($PLASTER_PARAM_Options -notcontains 'Pester')"
+              source='editor\VSCode\tasks_psake.json'
+              destination='.vscode\tasks.json' />
 
-            <replace condition="$PLASTER_PARAM_Options -contains 'psake' -and $PLASTER_FileContent -notmatch 'taskName&quot;:\s*&quot;Clean&quot;'">
-                <original><![CDATA[(?si)(?<="tasks":\s*\[)(\s*)(?=\{)]]></original>
-                <substitute><![CDATA[$1{
-            "taskName": "Clean",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake...'; Invoke-psake build.psake.ps1 -taskList Clean;",
-                "Invoke-Command { Write-Host 'Completed Clean task in task runner.' }"
-            ]
-        },$1]]></substitute>
-            </replace>
+        <file condition="($PLASTER_PARAM_Editor -eq 'VSCode') -and ($PLASTER_PARAM_Options -contains 'psake') -and ($PLASTER_PARAM_Options -contains 'Pester')"
+              source='editor\VSCode\tasks_psake_pester.json'
+              destination='.vscode\tasks.json' />
 
-            <replace condition="$PLASTER_PARAM_Options -contains 'psake' -and $PLASTER_FileContent -notmatch 'taskName&quot;:\s*&quot;Build&quot;'">
-                <original><![CDATA[(?si)(?<="tasks":\s*\[)(\s*)(?=\{)]]></original>
-                <substitute><![CDATA[$1{
-            "taskName": "Build",
-            "suppressTaskName": true,
-            "isBuildCommand": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake...'; Invoke-psake build.psake.ps1 -taskList Build;",
-                "Invoke-Command { Write-Host 'Completed Build task in task runner.' }"
-            ]
-        },$1]]></substitute>
-            </replace>
-
-            <replace condition="$PLASTER_PARAM_Options -contains 'psake' -and $PLASTER_FileContent -notmatch 'taskName&quot;:\s*&quot;Install&quot;'">
-                <original><![CDATA[(?si)(?<="tasks":\s*\[)(\s*)(?=\{)]]></original>
-                <substitute><![CDATA[$1{
-            "taskName": "Install",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake...'; Invoke-psake build.psake.ps1 -taskList Install;",
-                "Invoke-Command { Write-Host 'Completed Install task in task runner.' }"
-            ]
-        },$1]]></substitute>
-            </replace>
-
-            <replace condition="$PLASTER_PARAM_Options -contains 'psake' -and $PLASTER_FileContent -notmatch 'taskName&quot;:\s*&quot;Publish&quot;'">
-                <original><![CDATA[(?si)(?<="tasks":\s*\[)(\s*)(?=\{)]]></original>
-                <substitute><![CDATA[$1{
-            "taskName": "Publish",
-            "suppressTaskName": true,
-            "showOutput": "always",
-            "args": [
-                "Write-Host 'Invoking psake...'; Invoke-psake build.psake.ps1 -taskList Publish;",
-                "Invoke-Command { Write-Host 'Completed Publish task in task runner.' }"
-            ]
-        },$1]]></substitute>
-            </replace>
-        </modify>
-
-        <requireModule name="Pester" condition='$PLASTER_PARAM_Options -contains "Pester"'
-            minimumVersion="3.4.0"
+        <requireModule name="Pester" condition='$PLASTER_PARAM_Options -contains "Pester"' minimumVersion="3.4.0"
             message="Without Pester, you will not be able to run the provided Pester test to validate your module manifest file.`nWithout version 3.4.0, VS Code will not display Pester warnings and errors in the Problems panel."/>
 
         <requireModule name="psake" condition='$PLASTER_PARAM_Options -contains "psake"'
@@ -235,7 +142,7 @@ Scaffold a PowerShell Module with the files required to run Pester tests, build 
         <requireModule name="platyPS" condition='$PLASTER_PARAM_Options -contains "platyPS"'
             message="Without platyPS, you will not be able to generate PowerShell external help for your module using markdown."/>
 
-        <message >
+        <message>
 
 Your new PowerShell module project '$PLASTER_PARAM_ModuleName' has been created.
 

--- a/src/Templates/NewModule/plasterManifest.xml
+++ b/src/Templates/NewModule/plasterManifest.xml
@@ -122,6 +122,10 @@
                       source='license\MIT.txt'
                       destination='LICENSE.txt' />
 
+        <file condition="($PLASTER_PARAM_Editor -eq 'VSCode') -and ($PLASTER_PARAM_Options -notcontains 'psake') -and ($PLASTER_PARAM_Options -contains 'Pester')"
+              source='editor\VSCode\tasks_pester.json'
+              destination='.vscode\tasks.json' />
+
         <file condition="($PLASTER_PARAM_Editor -eq 'VSCode') -and ($PLASTER_PARAM_Options -contains 'psake') -and ($PLASTER_PARAM_Options -notcontains 'Pester')"
               source='editor\VSCode\tasks_psake.json'
               destination='.vscode\tasks.json' />
@@ -148,19 +152,19 @@ Your new PowerShell module project '$PLASTER_PARAM_ModuleName' has been created.
 
         </message>
 
-        <message condition="$PLASTER_PARAM_Options -contains 'psake'">
-You can build your project by executing the 'build' task.  Press Ctrl+P, then type 'task build'.
-You can publish your project to the PSGallery by pressing Ctrl+P, then type 'task publish'.
-
-        </message>
-
         <message condition="$PLASTER_PARAM_Options -contains 'Pester'">
 A Pester test has been created to validate the module's manifest file.  Add additional tests to the test directory.
 You can run the Pester tests in your project by executing the 'test' task.  Press Ctrl+P, then type 'task test'.
 
         </message>
 
-        <message condition="$PLASTER_PARAM_Options -contains 'platyPS'">
+        <message condition="$PLASTER_PARAM_Options -contains 'psake'">
+You can build your project by executing the 'build' task.  Press Ctrl+P, then type 'task build'.
+You can publish your project to the PSGallery by pressing Ctrl+P, then type 'task publish'.
+
+        </message>
+
+        <message condition="($PLASTER_PARAM_Options -contains 'psake') -and ($PLASTER_PARAM_Options -contains 'platyPS')">
 You can generate help and additional documentation using platyPS by running the 'build help' task.  Press Ctrl+P,
 then type 'task build help'.  Add additional documentation written in platyPS markdown to the docs directory. You can
 update the help by running the 'build help' task again.


### PR DESCRIPTION
Remove the ISE editor option as ATM we don't do anything special for ISE.  Also update the way we create the tasks.json file for VSCode.  We now pick between one of two tasks.json files depending the options the user selects.  This is cleaner and safer than trying to use <modifyFile>. Also update the tasks.json files to have them display the exact command they run (educates user how to use psake from command ilne) and update to find powershell on windows, linux and osx.

Update tasks.json commens to the latest generate by VSCode.