### PR TITLE
Rkeithhill/is206 message on create empty dir

### DIFF
--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -1027,6 +1027,8 @@ function Invoke-Plaster {
                 if (Test-Path -LiteralPath $srcPath -PathType Container) {
                     if (!(Test-Path -LiteralPath $dstPath)) {
                         if ($PSCmdlet.ShouldProcess($parentDir, $LocalizedData.ShouldProcessCreateDir)) {
+                            WriteOperationStatus $LocalizedData.OpCreate `
+                                ($dstRelPath.TrimEnd(([char]'\'),([char]'/')) + [System.IO.Path]::DirectorySeparatorChar)
                             New-Item -Path $dstPath -ItemType Directory > $null
                         }
                     }

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -1299,6 +1299,9 @@ function Invoke-Plaster {
                 $defaultValueStore | Export-Clixml -LiteralPath $defaultValueStorePath
             }
 
+            # Output the DestinationPath
+            $LocalizedData.DestPath_F1 -f $destinationAbsolutePath
+
             # Process content
             foreach ($node in $manifest.plasterManifest.content.ChildNodes) {
                 if ($node -isnot [System.Xml.XmlElement]) { continue }

--- a/src/Plaster.psm1
+++ b/src/Plaster.psm1
@@ -2,6 +2,7 @@
 data LocalizedData {
     # culture="en-US"
     ConvertFrom-StringData @'
+    DestPath_F1=Destination path: {0}
     ErrorFailedToLoadStoreFile_F1=Failed to load the default value store file: '{0}'.
     ErrorProcessingDynamicParams_F1=Failed to create dynamic parameters from the template's manifest file.  Template-based dynamic parameters will not be available until the error is corrected.  The error was: {0}
     ErrorTemplatePathIsInvalid_F1=The TemplatePath parameter value must refer to an existing directory. The specified path '{0}' does not.

--- a/src/en-US/Plaster.Resources.psd1
+++ b/src/en-US/Plaster.Resources.psd1
@@ -2,6 +2,7 @@
 
 ConvertFrom-StringData @'
 ###PSLOC
+DestPath_F1=Destination path: {0}
 ErrorFailedToLoadStoreFile_F1=Failed to load the default value store file: '{0}'.
 ErrorProcessingDynamicParams_F1=Failed to create dynamic parameters from the template's manifest file.  Template-based dynamic parameters will not be available until the error is corrected.  The error was: {0}
 ErrorTemplatePathIsInvalid_F1=The TemplatePath parameter value must refer to an existing directory. The specified path '{0}' does not.

--- a/test/RequireModule.Tests.ps1
+++ b/test/RequireModule.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Verify'
+            $output[1] | Should Match '^\s*Verify'
         }
 
         It 'It finds module based on minimumVersion' {
@@ -51,7 +51,7 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Verify'
+            $output[1] | Should Match '^\s*Verify'
         }
 
         It 'It finds module based on maximumVersion' {
@@ -77,7 +77,7 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Verify'
+            $output[1] | Should Match '^\s*Verify'
         }
 
         It 'It finds module based on minimumVersion and maximumVersion' {
@@ -103,7 +103,7 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Verify'
+            $output[1] | Should Match '^\s*Verify'
         }
 
         It 'It finds module based on requiredVersion' {
@@ -131,7 +131,7 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Verify'
+            $output[1] | Should Match '^\s*Verify'
         }
     }
 
@@ -160,7 +160,7 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Missing'
+            $output[1] | Should Match '^\s*Missing'
         }
 
         It 'Determines minimum version of module is missing' {
@@ -186,7 +186,7 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Missing'
+            $output[1] | Should Match '^\s*Missing'
         }
 
         It 'Determines maximum version of module is missing' {
@@ -212,7 +212,7 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Missing'
+            $output[1] | Should Match '^\s*Missing'
         }
 
         It 'Determines required version of module is missing' {
@@ -238,7 +238,7 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Missing'
+            $output[1] | Should Match '^\s*Missing'
         }
     }
 
@@ -267,7 +267,7 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Verify'
+            $output[1] | Should Match '^\s*Verify'
         }
 
         It 'False condition does not evaluate requireModule directive' {
@@ -293,7 +293,8 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Be ''
+            "$output" | Should Match "^Destination path:"
+            $output.Count | Should Be 1
         }
     }
 
@@ -324,8 +325,8 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Missing'
-            "$output" | Should Match $message
+            $output[1] | Should Match '^\s*Missing'
+            $output[3] | Should Match $message
         }
 
         It 'Does not output message when module is found' {
@@ -353,8 +354,8 @@ Describe 'RequireModule Directive Tests' {
 
             $OFS = ''
             $output = Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6>&1
-            "$output" | Should Match '^\s*Verify'
-            "$output" -notmatch $message | Should Be $true
+            $output[1] | Should Match '^\s*Verify'
+            $output[1] -notmatch $message | Should Be $true
         }
     }
 


### PR DESCRIPTION
Displays the DestinationPath and a create message when an "empty" dir is created.

I think this is all we will get to before the initial release.  I want to keep the output a simple, flat list for now. 

Fix #206