### PR TITLE
Implement Get-PlasterTemplate

### DIFF
--- a/docs/en-US/Get-PlasterTemplate.md
+++ b/docs/en-US/Get-PlasterTemplate.md
@@ -1,0 +1,143 @@
+---
+external help file: Plaster-help.xml
+online version: https://github.com/PowerShell/Plaster/blob/master/docs/en-US/Get-PlasterTemplate.md
+schema: 2.0.0
+---
+
+# Get-PlasterTemplate
+
+## SYNOPSIS
+Retrieves a list of available Plaster templates that can be used with the Invoke-Plaster
+cmdlet.
+
+## SYNTAX
+
+### Path
+```
+Get-PlasterTemplate [[-Path] <String>] [-Recurse] [<CommonParameters>]
+```
+
+### IncludedTemplates
+```
+Get-PlasterTemplate [-IncludeInstalledModules] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves a list of available Plaster templates from the specified path or from
+the set of templates that are shipped with Plaster.  Specifying no arguments will
+cause only the built-in Plaster templates to be returned.  Using the -IncludeInstalledModules
+switch will also search the PSModulePath for PowerShell modules that advertise
+Plaster templates that they include.
+
+
+The objects returned from this cmdlet will provide details about each individual
+template that was retrieved.  Use the TemplatePath property of a template object as
+the input to Invoke-Plaster's -TemplatePath parameter.
+
+## EXAMPLES
+
+### Example 1
+```
+PS C:\> $templates = Get-PlasterTemplate
+
+PS C:\> Invoke-Plaster -TemplatePath $templates[0].TemplatePath -DestinationPath ~\GitHub\NewModule
+```
+
+This will get the list of built-in Plaster templates.  The first template returned is then used to
+create a new module at the specifed path.
+
+### Example 2
+```
+PS C:\> $templates = Get-PlasterTemplate -IncludeInstalledModules
+
+PS C:\> Invoke-Plaster -TemplatePath $templates[0].TemplatePath -DestinationPath ~\GitHub\NewModule
+```
+
+This will get a list of Plaster templates, both built-in and included with installed
+modules.  The first template returned is then used to create a new module at
+the specifed path.
+
+### Example 3
+```
+PS C:\> $templates = Get-PlasterTemplate -Path c:\MyPlasterTemplates -Recurse
+
+PS C:\> Invoke-Plaster -TemplatePath $templates[0].TemplatePath -DestinationPath ~\GitHub\NewModule
+```
+
+This will get a list of Plaster templates found recursively under c:\MyPlasterTemplates
+The first template returned is then used to create a new module at the specifed path.
+
+## PARAMETERS
+
+### -IncludeInstalledModules
+Initiates a search for Plaster templates inside of installed modules.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: IncludedTemplates
+Aliases: IncludeModules
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+Specifies a path to a folder containing a Plaster template or multiple template folders.
+Can also be a path to plasterManifest.xml.
+
+```yaml
+Type: String
+Parameter Sets: Path
+Aliases: 
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Recurse
+Indicates that this cmdlet gets the items in the specified locations and in all child items of the locations.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Path
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String
+The first positional parameter is a filesystem path under which templates might be
+found.  The -Recurse switch will cause this path to be searched recursively.
+
+## OUTPUTS
+
+### System.Object
+This output object provides the following properties:
+
+- Title: The title of the template
+- Author: The author of the template
+- Version: The version of the template
+- Description: Text describing the template and what it creates
+- Tags: A list of tag strings which categorize the template
+- TemplatePath: The template's folder path in the filesystem
+
+## NOTES
+
+## RELATED LINKS
+
+[Invoke-Plaster](https://github.com/PowerShell/Plaster/blob/master/docs/en-US/Invoke-Plaster.md)

--- a/docs/en-US/New-PlasterManifest.md
+++ b/docs/en-US/New-PlasterManifest.md
@@ -12,9 +12,9 @@ Creates a new Plaster template manifest file.
 ## SYNTAX
 
 ```
-New-PlasterManifest [[-Path] <String>] -TemplateName <String> [-Id <Guid>] [-TemplateVersion <String>]
- [-Title <String>] [-Description <String>] [-Tags <String[]>] [-Author <String>] [-AddContent] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+New-PlasterManifest [[-Path] <String>] [-TemplateName] <String> [[-Id] <Guid>] [[-TemplateVersion] <String>]
+ [[-Title] <String>] [[-Description] <String>] [[-Tags] <String[]>] [[-Author] <String>] [-AddContent]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -77,7 +77,7 @@ manifest's content element.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
 Required: False
 Position: Named
@@ -92,10 +92,10 @@ Specifies the author of the template.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
 Required: False
-Position: Named
+Position: 7
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -127,10 +127,10 @@ tests, building with psake and publishing to the PowerShell Gallery."
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
 Required: False
-Position: Named
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -149,10 +149,10 @@ template.
 ```yaml
 Type: Guid
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
 Required: False
-Position: Named
+Position: 2
 Default value: [guid]::NewGuid()
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -170,10 +170,10 @@ The default, if no value is provided is to create plasterManifest.xml in the cur
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
 Required: False
-Position: Named
+Position: 0
 Default value: "$pwd\plasterManifest.xml"
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -186,10 +186,10 @@ Users can search for templates based on these tags.
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
 Required: False
-Position: Named
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -205,10 +205,10 @@ The name is limited to the characters: aA-zZ0-9_-.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
 Required: True
-Position: Named
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -220,10 +220,10 @@ Specifies the version of the template.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
 Required: False
-Position: Named
+Position: 3
 Default value: 1.0.0
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -238,10 +238,10 @@ A typical title might be "New DSC Resource" or "New PowerShell Module".
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: 
 
 Required: False
-Position: Named
+Position: 4
 Default value: $Name
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/docs/en-US/Plaster.md
+++ b/docs/en-US/Plaster.md
@@ -16,6 +16,9 @@ PowerShell DSC module or DSC resource.
 ### [Invoke-Plaster](Invoke-Plaster.md)
 Invokes the specified Plaster template which will scaffold out a file or a set of files and directories.
 
+### [Get-PlasterTemplate](Get-PlasterTemplate.md)
+Retrieves available Plaster templates which can be scaffolded with Invoke-Plaster.
+
 ### [New-PlasterManifest](New-PlasterManifest.md)
 Creates a new Plaster template manifest file.
 

--- a/docs/en-US/Test-PlasterManifest.md
+++ b/docs/en-US/Test-PlasterManifest.md
@@ -12,7 +12,7 @@ Verifies that a plaster manifest file is a valid.
 ## SYNTAX
 
 ```
-Test-PlasterManifest [[-Path] <String>] [<CommonParameters>]
+Test-PlasterManifest [[-Path] <String[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/examples/TemplateModule/README.md
+++ b/examples/TemplateModule/README.md
@@ -1,0 +1,34 @@
+# Plaster Template Module Example
+
+This file contains a simple PowerShell module which includes a Plaster template.
+The important part to note is in the `PrivateData` section of the `TemplateModule.psd1`
+file:
+
+```powershell
+PrivateData = @{
+
+    PSData = @{
+
+        Extensions = @(
+            @{
+                Module = "Plaster"
+                MinimumVersion = "0.3.0"
+                Details = @{
+                    TemplatePaths = @("TemplateOne", "TemplateTwo")
+                }
+            }
+        )
+    } # End of PSData hashtable
+
+} # End of PrivateData hashtable
+```
+
+A PowerShell module which includes Plaster templates should add an `Extensions` section
+in their `PrivateData.PSData` object using the format shown above.  You can target a specific
+version range of Plaster using the `MinimumVersion` (shown) and `MaximumVersion` properties
+(not shown).  For now the only property in the `Details` object is `TemplatePaths` which
+is a simple list of folder paths under the module's installation path which contain `plasterManifest.xml`
+files.
+
+The `TemplateOne` and `TemplateTwo` subfolders both contain a simple, standard `plasterManifest.xml`
+which needs no extra configuration to be shipped as part of a PowerShell module.

--- a/examples/TemplateModule/TemplateModule.psd1
+++ b/examples/TemplateModule/TemplateModule.psd1
@@ -1,0 +1,59 @@
+﻿#
+# Module manifest for module 'TemplateModule'
+#
+
+@{
+
+# Version number of this module.
+ModuleVersion = '1.0'
+
+# ID used to uniquely identify this module
+GUID = '42225364-811c-47de-8828-54f79d0aa599'
+
+# Author of this module
+Author = 'Microsoft Corporation'
+
+# Company or vendor of this module
+CompanyName = 'Microsoft Corporation'
+
+# Copyright statement for this module
+Copyright = '(c) 2016 Microsoft Corporation. All rights reserved.'
+
+# Description of the functionality provided by this module
+Description = 'Provides an example module which contains a Plaster template'
+
+# Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+FunctionsToExport = @()
+
+# Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+CmdletsToExport = @()
+
+# Variables to export from this module
+VariablesToExport = '*'
+
+# Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+AliasesToExport = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+PrivateData = @{
+
+    PSData = @{
+
+        Extensions = @(
+            @{
+                Module = "Plaster"
+                MinimumVersion = "0.3.0"
+                Details = @{
+                    TemplatePaths = @("TemplateOne", "TemplateTwo")
+                }
+            }
+        )
+    } # End of PSData hashtable
+
+} # End of PrivateData hashtable
+
+}
+

--- a/examples/TemplateModule/TemplateOne/plasterManifest.xml
+++ b/examples/TemplateModule/TemplateOne/plasterManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest
+  schemaVersion="0.4" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+  <metadata>
+    <name>TemplateOneTemplate</name>
+    <id>635046f0-a59b-46a0-b6b3-892084707467</id>
+    <version>0.1.0</version>
+    <title>TemplateOne Template</title>
+    <description>An example Plaster template from a PowerShell module.</description>
+    <author>Plaster project</author>
+    <tags>Module, ModuleManifest</tags>
+  </metadata>
+  <parameters>
+        <parameter name='ModuleName'
+                   type='text'
+                   prompt='Enter the name of the module'/>
+  </parameters>
+
+  <content>
+        <newModuleManifest destination='${PLASTER_PARAM_ModuleName}.psd1'
+                           moduleVersion='$PLASTER_PARAM_Version'
+                           rootModule='${PLASTER_PARAM_ModuleName}.psm1'
+                           encoding='UTF8-NoBOM'/>
+  </content>
+</plasterManifest>

--- a/examples/TemplateModule/TemplateTwo/plasterManifest.xml
+++ b/examples/TemplateModule/TemplateTwo/plasterManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest
+  schemaVersion="0.4" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+  <metadata>
+    <name>TemplateTwoTemplate</name>
+    <id>76a18e25-3c2f-4266-9a6f-64cdef44de94</id>
+    <version>0.1.0</version>
+    <title>TemplateTwo Template</title>
+    <description>An example Plaster template from a PowerShell module.</description>
+    <author>Plaster project</author>
+    <tags>Module, ModuleManifest</tags>
+  </metadata>
+  <parameters>
+        <parameter name='ModuleName'
+                   type='text'
+                   prompt='Enter the name of the module'/>
+  </parameters>
+
+  <content>
+        <newModuleManifest destination='${PLASTER_PARAM_ModuleName}.psd1'
+                           moduleVersion='$PLASTER_PARAM_Version'
+                           rootModule='${PLASTER_PARAM_ModuleName}.psm1'
+                           encoding='UTF8-NoBOM'/>
+  </content>
+</plasterManifest>

--- a/src/GetModuleExtension.ps1
+++ b/src/GetModuleExtension.ps1
@@ -1,0 +1,65 @@
+function Get-ModuleExtension {
+    [CmdletBinding()]
+    param(
+        [string]
+        $ModuleName,
+
+        [Version]
+        $ModuleVersion
+    )
+
+    $modules = Get-Module -ListAvailable
+    Write-Verbose "`nFound $($modules.Length) installed modules to scan for extensions."
+
+    function ParseVersion($versionString) {
+        $parsedVersion = $null
+
+        if ($versionString) {
+            # We're targeting Semantic Versioning 2.0 so make sure the version has
+            # at least 3 components (X.X.X).  This logic ensures that the "patch"
+            # (third) component has been specified.
+            $versionParts = $versionString.Split('.');
+            if ($versionParts.Length -lt 3) {
+                $versionString = "$versionString.0"
+            }
+
+            if ($PSVersionTable.PSEdition -eq "Core") {
+                $parsedVersion = New-Object -TypeName "System.Management.Automation.SemanticVersion" -ArgumentList $versionString
+            }
+            else {
+                $parsedVersion = New-Object -TypeName "System.Version" -ArgumentList $versionString
+            }
+        }
+
+        return $parsedVersion
+    }
+
+    foreach ($module in $modules) {
+        if ($module.PrivateData -and
+            $module.PrivateData.PSData -and
+            $module.PrivateData.PSData.Extensions) {
+
+            Write-Verbose "Found module with extensions: $($module.Name)"
+
+            foreach ($extension in $module.PrivateData.PSData.Extensions) {
+
+                Write-Verbose "Comparing against module extension: $($extension.Module)"
+
+                $minimumVersion = ParseVersion $extension.MinimumVersion
+                $maximumVersion = ParseVersion $extension.MaximumVersion
+
+                if (($extension.Module -eq $ModuleName) -and
+                    (!$minimumVersion -or $ModuleVersion -ge $minimumVersion) -and
+                    (!$maximumVersion -or $ModuleVersion -le $maximumVersion)) {
+                    # Return a new object with the extension information
+                    [PSCustomObject]@{
+                        Module = $module
+                        MinimumVersion = $minimumVersion
+                        MaximumVersion = $maximumVersion
+                        Details = $extension.Details
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/GetPlasterTemplate.ps1
+++ b/src/GetPlasterTemplate.ps1
@@ -1,0 +1,92 @@
+. $PSScriptRoot\GetModuleExtension.ps1
+
+function Get-PlasterTemplate {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0,
+                   ParameterSetName="Path",
+                   HelpMessage="Specifies a path to a folder containing a Plaster template or multiple template folders.  Can also be a path to plasterManifest.xml.")]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path,
+
+        [Parameter(ParameterSetName="Path",
+                   HelpMessage="Indicates that this cmdlet gets the items in the specified locations and in all child items of the locations.")]
+        [switch]
+        $Recurse,
+
+        [Parameter(Position=0,
+                   Mandatory=$true,
+                   ParameterSetName="IncludedTemplates",
+                   HelpMessage="Initiates a search for Plaster templates inside of installed modules.")]
+        [switch]
+        [Alias("IncludeModules")]
+        $IncludeInstalledModules
+    )
+
+    process {
+        function CreateTemplateObjectFromManifest([System.IO.FileInfo]$manifestPath) {
+
+            $manifestXml = Test-PlasterManifest -Path $manifestPath
+            $metadata = $manifestXml["plasterManifest"]["metadata"]
+
+            $manifestObj = [PSCustomObject]@{
+                Title = $metadata["title"].InnerText
+                Author = $metadata["author"].InnerText
+                Version = New-Object -TypeName "System.Version" -ArgumentList $metadata["version"].InnerText
+                Description = $metadata["description"].InnerText
+                Tags = $metadata["tags"].InnerText.split(",") | % { $_.Trim() }
+                TemplatePath = $manifestPath.Directory.FullName
+            }
+
+            $manifestObj.PSTypeNames.Insert(0, "Microsoft.PowerShell.Plaster.PlasterTemplate")
+            return $manifestObj
+        }
+
+        function GetManifestsUnderPath([string]$rootPath, [bool]$recurse) {
+            $manifestPaths = Get-ChildItem -Path $rootPath -Include "plasterManifest.xml" -Recurse:$recurse
+            foreach ($manifestPath in $manifestPaths) {
+                CreateTemplateObjectFromManifest $manifestPath -ErrorAction SilentlyContinue
+            }
+        }
+
+        if ($Path) {
+            # Is this a folder path or a Plaster manifest file path?
+            if (!$Recurse.IsPresent) {
+                if (Test-Path $Path -PathType Container) {
+                    $Path = Resolve-Path "$Path/plasterManifest.xml"
+                }
+
+                # Use Test-PlasterManifest to load the manifest file
+                Write-Verbose "Attempting to get Plaster template at path: $Path"
+                CreateTemplateObjectFromManifest $Path
+            }
+            else {
+                Write-Verbose "Attempting to get Plaster templates recursively under path: $Path"
+                GetManifestsUnderPath $Path $Recurse.IsPresent
+            }
+        }
+        else {
+            # Return all templates included with Plaster
+            GetManifestsUnderPath "$PSScriptRoot\Templates" $true
+
+            if ($IncludeInstalledModules.IsPresent) {
+                # Search for templates in module path
+                $extensions = Get-ModuleExtension -ModuleName Plaster -ModuleVersion $PlasterVersion
+
+                foreach ($extension in $extensions) {
+                    # Scan all module paths registered in the module
+                    foreach ($templatePath in $extension.Details.TemplatePaths) {
+                        $expandedTemplatePath =
+                            [System.IO.Path]::Combine(
+                                $extension.Module.ModuleBase,
+                                $templatePath,
+                                "plasterManifest.xml")
+
+                        CreateTemplateObjectFromManifest $expandedTemplatePath -ErrorAction SilentlyContinue
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -134,6 +134,24 @@ function Invoke-Plaster {
     }
 
     begin {
+        # Write out the Plaster logo if necessary
+        $plasterLogo = @'
+  ____  _           _
+ |  _ \| | __ _ ___| |_ ___ _ __
+ | |_) | |/ _` / __| __/ _ \ '__|
+ |  __/| | (_| \__ \ ||  __/ |
+ |_|   |_|\__,_|___/\__\___|_|
+'@
+
+        if (!$NoLogo) {
+            $versionString = "v$PlasterVersion"
+            Write-Host $plasterLogo
+            Write-Host ((" " * (50 - $versionString.Length)) + $versionString)
+            Write-Host ("=" * 50)
+        }
+    }
+
+    process {
         $boundParameters = $PSBoundParameters
         $constrainedRunspace = $null
         $templateCreatedFiles = @{}
@@ -143,14 +161,6 @@ function Invoke-Plaster {
         $flags = @{
             DefaultValueStoreDirty = $false
         }
-
-        $plasterLogo = @'
-  ____  _           _
- |  _ \| | __ _ ___| |_ ___ _ __
- | |_) | |/ _` / __| __/ _ \ '__|
- |  __/| | (_| \__ \ ||  __/ |
- |_|   |_|\__,_|___/\__\___|_|
-'@
 
         # Verify TemplatePath parameter value is valid.
         $templateAbsolutePath = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($TemplatePath)
@@ -172,11 +182,6 @@ function Invoke-Plaster {
             else {
                 throw ($LocalizedData.ManifestFileMissing_F1 -f $manifestPath)
             }
-        }
-
-        if (!$NoLogo) {
-            Write-Host $plasterLogo
-            Write-Host ("=" * 50)
         }
 
         # If the destination path doesn't exist, create it.

--- a/src/Plaster.psd1
+++ b/src/Plaster.psd1
@@ -52,6 +52,7 @@
     FunctionsToExport = @(
         'Invoke-Plaster'
         'New-PlasterManifest'
+        'Get-PlasterTemplate',
         'Test-PlasterManifest'
         )
 

--- a/src/Plaster.psm1
+++ b/src/Plaster.psm1
@@ -70,6 +70,8 @@ Microsoft.PowerShell.Utility\Import-LocalizedData LocalizedData -FileName Plaste
 
 # Module variables
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
+$PlasterVersion = (Test-ModuleManifest -Path $PSScriptRoot\Plaster.psd1).Version
+[System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $LatestSupportedSchemaVersion = [System.Version]'1.0'
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $TargetNamespace = "http://www.microsoft.com/schemas/PowerShell/Plaster/v1"
@@ -93,6 +95,7 @@ else {
 # Dot source the individual module command scripts.
 . $PSScriptRoot\NewPlasterManifest.ps1
 . $PSScriptRoot\TestPlasterManifest.ps1
+. $PSScriptRoot\GetPlasterTemplate.ps1
 . $PSScriptRoot\InvokePlaster.ps1
 
 Export-ModuleMember -Function *-*

--- a/test/GetPlasterTemplate.Tests.ps1
+++ b/test/GetPlasterTemplate.Tests.ps1
@@ -1,0 +1,34 @@
+. $PSScriptRoot\Shared.ps1
+
+Describe 'Get-PlasterTemplate' {
+    $examplesPath = Resolve-Path "$PSScriptRoot/../examples/"
+
+    Context "when given a path" {
+        It "finds the contained template" {
+            $templates = Get-PlasterTemplate -Path "$examplesPath/NewModule"
+            $templates[0].Title | Should Be "New Module"
+        }
+
+        It "finds templates recursively" {
+            $templates = Get-PlasterTemplate -Path "$PSScriptRoot/../examples/" -Recurse
+            $templates[0].Title | Should Be "New DSC Resource Script File"
+        }
+    }
+
+    Context "when searching modules for templates" {
+        It "finds built-in templates" {
+            $templates = Get-PlasterTemplate
+            $templates[0].Title | Should Be "New PowerShell Manifest Module"
+        }
+
+        It "finds templates included with modules" {
+            $oldPSModulePath = $env:PSModulePath;
+            $env:PSModulePath = "$(Resolve-Path "$PSScriptRoot/../examples")$([System.IO.Path]::PathSeparator)$($env:PSModulePath)";
+
+            $templates = Get-PlasterTemplate -IncludeInstalledModules
+            $templates[1].Title | Should Be "TemplateOne Template"
+
+            $env:PSModulePath = $oldPSModulePath
+        }
+    }
+}


### PR DESCRIPTION
This change adds a Get-PlasterTemplate cmdlet which is capable of the following:

- Listing built-in Plaster templates that come with the module
- Finding Plaster templates recursively under a given folder path
- Finding Plaster templates that were shipped with an installed PowerShell module

The `TemplatePath` property of the resulting template objects can be passed directly into `Invoke-PlasterTemplate`.