### PR TITLE
Add plasterVersion to manifest schema.

### DIFF
--- a/docs/en-US/about_Plaster_CreatingAManifest.help.md
+++ b/docs/en-US/about_Plaster_CreatingAManifest.help.md
@@ -401,6 +401,7 @@ In addition to these variables, Plaster defines a set of built-in variables:
 - PLASTER_FileContent     - The contents of a file be modified via the `<modify>` directive.
 - PLASTER_DirSepChar      - The directory separator char for the platform.
 - PLASTER_HostName        - The PowerShell host name e.g. $Host.Name
+- PLASTER_Version         - The version of the Plaster module invoking the template.
 - PLASTER_Guid1           - Randomly generated GUID value
 - PLASTER_Guid2           - Randomly generated GUID value
 - PLASTER_Guid3           - Randomly generated GUID value

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -1341,6 +1341,7 @@ function InitializePredefinedVariables([string]$TemplatePath, [string]$DestPath)
     Set-Variable -Name PLASTER_DestinationName -Value $destName -Scope Script
     Set-Variable -Name PLASTER_DirSepChar      -Value ([System.IO.Path]::DirectorySeparatorChar) -Scope Script
     Set-Variable -Name PLASTER_HostName        -Value $Host.Name -Scope Script
+    Set-Variable -Name PLASTER_Version         -Value $MyInvocation.MyCommand.Module.Version -Scope Script
 
     Set-Variable -Name PLASTER_Guid1 -Value ([Guid]::NewGuid()) -Scope Script
     Set-Variable -Name PLASTER_Guid2 -Value ([Guid]::NewGuid()) -Scope Script

--- a/src/Plaster.psm1
+++ b/src/Plaster.psm1
@@ -24,6 +24,7 @@ data LocalizedData {
     ManifestFileMissing_F1=The Plaster manifest file '{0}' was not found.
     ManifestMissingDocElement_F2=The Plaster manifest file '{0}' is missing the document element. It should be specified as <plasterManifest xmlns="{1}"></plasterManifest>.
     ManifestMissingDocTargetNamespace_F2=The Plaster manifest file '{0}' is missing or has an invalid target namespace on the document element. It should be specified as <plasterManifest xmlns="{1}"></plasterManifest>.
+    ManifestPlasterVersionNotSupported_F2=The template file '{0}' specifies a plasterVersion of {1} which is greater than the installed version of Plaster. Update the Plaster module and try again.
     ManifestSchemaInvalidAttrValue_F5=Invalid '{0}' attribute value '{1}' on '{2}' element in file '{3}'. Error: {4}
     ManifestSchemaInvalidCondition_F3=Invalid condition '{0}' in file '{1}'. Error: {2}
     ManifestSchemaInvalidChoiceDefault_F3=Invalid default attribute value '{0}' for parameter '{1}' in file '{2}'. The default value must specify a zero-based integer index that corresponds to the default choice.
@@ -69,7 +70,7 @@ Microsoft.PowerShell.Utility\Import-LocalizedData LocalizedData -FileName Plaste
 
 # Module variables
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-$LatestSupportedSchemaVersion = [System.Version]'0.4'
+$LatestSupportedSchemaVersion = [System.Version]'0.5'
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
 $TargetNamespace = "http://www.microsoft.com/schemas/PowerShell/Plaster/v1"
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]

--- a/src/Schema/PlasterManifest-v1.xsd
+++ b/src/Schema/PlasterManifest-v1.xsd
@@ -10,7 +10,7 @@
 	targetNamespace="http://www.microsoft.com/schemas/PowerShell/Plaster/v1"
 	elementFormDefault="qualified"
   attributeFormDefault="unqualified"
-  version="0.4"
+  version="0.5"
   xml:lang="en"
 	xmlns:vs="http://schemas.microsoft.com/Visual-Studio-Intellisense"
 		vs:friendlyname="Plaster Manifest Schema"
@@ -479,7 +479,12 @@
 
       <xs:attribute name="schemaVersion" type="ptd:SchemaVersionType" use="required">
         <xs:annotation>
-          <xs:documentation>Version level of the associated XML schema. Only breaking changes to the XML schema result in a new target namespace.</xs:documentation>
+          <xs:documentation>Version level of the associated XML schema. Use this when the Plaster template schema has beed updated with features required by the template. Only breaking changes to the XML schema result in a new target namespace.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="plasterVersion" type="ptd:ModuleVersionType">
+        <xs:annotation>
+          <xs:documentation>Specifies the minimum version of Plaster required to invoke the template. Use this when the Plaster engine has been updated with new functionality required by the template.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
     </xs:complexType>

--- a/src/en-US/Plaster.Resources.psd1
+++ b/src/en-US/Plaster.Resources.psd1
@@ -24,6 +24,7 @@ FileConflict=Plaster file conflict
 ManifestFileMissing_F1=The Plaster manifest file '{0}' was not found.
 ManifestMissingDocElement_F2=The Plaster manifest file '{0}' is missing the document element. It should be specified as <plasterManifest xmlns="{1}"></plasterManifest>.
 ManifestMissingDocTargetNamespace_F2=The Plaster manifest file '{0}' is missing or has an invalid target namespace on the document element. It should be specified as <plasterManifest xmlns="{1}"></plasterManifest>.
+ManifestPlasterVersionNotSupported_F2=The template file '{0}' specifies a plasterVersion of {1} which is greater than the installed version of Plaster. Update the Plaster module and try again.
 ManifestSchemaInvalidAttrValue_F5=Invalid '{0}' attribute value '{1}' on '{2}' element in file '{3}'. Error: {4}
 ManifestSchemaInvalidCondition_F3=Invalid condition '{0}' in file '{1}'. Error: {2}
 ManifestSchemaInvalidChoiceDefault_F3=Invalid default attribute value '{0}' for parameter '{1}' in file '{2}'. The default value must specify a zero-based integer index that corresponds to the default choice.

--- a/test/NewPlasterManifest.Tests.ps1
+++ b/test/NewPlasterManifest.Tests.ps1
@@ -1,5 +1,7 @@
 . $PSScriptRoot\Shared.ps1
 
+$LatestSchemaVersion = $plasterModule.Invoke({$LatestSupportedSchemaVersion})
+
 function CompareManifestContent($expectedManifest, $actualManifestPath) {
     # Compare the manifests while accounting for possible newline incompatiblity
     $expectedManifest = $expectedManifest -replace "`r`n", "`n"
@@ -15,7 +17,7 @@ Describe 'New-PlasterManifest Command Tests' {
             $expectedManifest = @"
 <?xml version="1.0" encoding="utf-8"?>
 <plasterManifest
-  schemaVersion="0.4" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+  schemaVersion="$LatestSchemaVersion" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
   <metadata>
     <name>TemplateName</name>
     <id>1a1b0933-78b2-4a3e-bf48-492591e69521</id>
@@ -41,7 +43,7 @@ Describe 'New-PlasterManifest Command Tests' {
             $expectedManifest = @"
 <?xml version="1.0" encoding="utf-8"?>
 <plasterManifest
-  schemaVersion="0.4" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+  schemaVersion="$LatestSchemaVersion" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
   <metadata>
     <name>TemplateName</name>
     <id>1a1b0933-78b2-4a3e-bf48-492591e69521</id>
@@ -67,7 +69,7 @@ Describe 'New-PlasterManifest Command Tests' {
             $expectedManifest = @"
 <?xml version="1.0" encoding="utf-8"?>
 <plasterManifest
-  schemaVersion="0.4" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+  schemaVersion="$LatestSchemaVersion" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
   <metadata>
     <name>TemplateName</name>
     <id>1a1b0933-78b2-4a3e-bf48-492591e69521</id>
@@ -93,7 +95,7 @@ Describe 'New-PlasterManifest Command Tests' {
             $expectedManifest = @"
 <?xml version="1.0" encoding="utf-8"?>
 <plasterManifest
-  schemaVersion="0.4" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+  schemaVersion="$LatestSchemaVersion" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
   <metadata>
     <name>TemplateName</name>
     <id>1a1b0933-78b2-4a3e-bf48-492591e69521</id>

--- a/test/Shared.ps1
+++ b/test/Shared.ps1
@@ -7,7 +7,7 @@ $PlasterManifestPath = "$TemplateDir\plasterManifest.xml"
 if (!$SuppressImportModule) {
     # -Scope Global is needed when running tests from inside of psake, otherwise
     # the module's functions cannot be found in the Plaster\ namespace
-    Import-Module $ModuleManifestPath -Scope Global
+    $plasterModule = Import-Module $ModuleManifestPath -Scope Global -PassThru
 }
 
 function CleanDir {


### PR DESCRIPTION
The plasterVersion is usefully when a newer version of Plaster supports a new runtime behavior (typically new commands and/or variables in the constrained runspace) and a template needs that behavior.  The presence of this attribute will cause Test-PlasterManifest (and Invoke-PlasterTemplate) to validate that the Plaster version is high enough.  If not, an error message is emitted telling the user to update the Plaster module.

Also added a new constrained runspace variable PLASTER_Version for runtime checks.  This can be used when the template can fallback gracefully depending on the version of Plaster.