### PR TITLE
Remove GenerateFileCatalog task from AppVeyor CI script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
 build_script:
   - ps: |
       $testResultsFile = Join-Path $pwd -ChildPath "$PSScriptRoot/TestResults.xml"
-      Invoke-psake build.psake.ps1 -taskList Test, BuildHelp, GenerateFileCatalog -properties @{"TestOutputFile" = $testResultsFile}
+      Invoke-psake build.psake.ps1 -taskList Test, BuildHelp -properties @{"TestOutputFile" = $testResultsFile}
       if ($psake.build_success -and (Test-Path $testResultsFile)) {
           (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", $testResultsFile)
       }


### PR DESCRIPTION
Turns out that we need to generate the file catalog after the module files
have been signed with Microsoft's certificates so it's better to not even
create it until then.