### PR TITLE
Added 2 helper functions for creating plaster manifest files. Updated…

### DIFF
--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -786,15 +786,28 @@ function Invoke-Plaster {
             # Pull all the new-modulemanifest parameters to account for future version changes and such
             $CmdParams = (Get-Command New-ModuleManifest).Parameters
 
-            # Some ignored parameters that we either overwrite or will not be splatting
-            $IgnoredManifestVals = @('Path', 'PrivateData', 'PassThru')
+            # Some ignored parameters that we either overwrite (like Path) or will not be splatting (the adv function variables)
+            $IgnoredManifestVals = @(
+                'Path',
+                'PrivateData',
+                'PassThru',
+                'Verbose',
+                'Debug',
+                'ErrorAction',
+                'WarningAction',
+                'InformationAction',
+                'ErrorVariable',
+                'WarningVariable',
+                'InformationVariable',
+                'OutVariable',
+                'OutBuffer',
+                'PipelineVariable',
+                'WhatIf',
+                'Confirm'
+            )
 
             # Get all non-advanced function parameters that new-modulemanifest uses
-            $ValidModuleManifestParams = $CmdParams.keys | ForEach-Object {
-                if (($CmdParams[$_].Attributes.TypeId.Name -notcontains 'AliasAttribute') -and ($IgnoredManifestVals -notcontains $_)) {
-                    $_
-                }
-            }
+            $ValidModuleManifestParams = $CmdParams.keys | Where-Object {($IgnoredManifestVals -notcontains $_)}
 
             # Create a hash of parameter types so we know how to process module manifest entries (as arrays or strings)
             $paramTypes = @{}

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -820,7 +820,8 @@ function Invoke-Plaster {
                 $PSCmdlet.WriteDebug("Determining how to handle the modulemanifest property - $ModProp.")
                 $PropVal = InterpolateAttributeValue $Node.$ModProp (GetErrorLocationNewModManifestAttrVal $ModProp)
                 # We are only concerned about the values which align with a new-modulemanifest parameter
-                if (![string]::IsNullOrWhiteSpace($PropVal) -and ($ValidModuleManifestParams -contains $ModProp)) {
+                if ($PropVal -and ($ValidModuleManifestParams -contains $ModProp)) {
+                #if (![string]::IsNullOrWhiteSpace($PropVal) -and ($ValidModuleManifestParams -contains $ModProp)) {
                     # take action based on the type of parameter being splatted
                     switch ($ParamTypes[$ModProp]) {
                         'System.Array' {

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -820,7 +820,7 @@ function Invoke-Plaster {
                 $PSCmdlet.WriteDebug("Determining how to handle the modulemanifest property - $ModProp.")
                 $PropVal = InterpolateAttributeValue $Node.$ModProp (GetErrorLocationNewModManifestAttrVal $ModProp)
                 # We are only concerned about the values which align with a new-modulemanifest parameter
-                if ($PropVal -and ($ValidModuleManifestParams -contains $ModProp)) {
+                if (($null -ne $PropVal) -and ($ValidModuleManifestParams -contains $ModProp)) {
                 #if (![string]::IsNullOrWhiteSpace($PropVal) -and ($ValidModuleManifestParams -contains $ModProp)) {
                     # take action based on the type of parameter being splatted
                     switch ($ParamTypes[$ModProp]) {

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -14,14 +14,14 @@
 ##  4. Please follow the scripting style of this file when adding new script.
 
 function Invoke-Plaster {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidShouldContinueWithoutForce', '', Scope='Function', Target='CopyFileWithConflictDetection')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '', Scope='Function', Target='ProcessParameter')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope='Function', Target='CopyFileWithConflictDetection')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope='Function', Target='ProcessFile')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope='Function', Target='ProcessModifyFile')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope='Function', Target='ProcessNewModuleManifest')]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope='Function', Target='ProcessRequireModule')]
-    [CmdletBinding(SupportsShouldProcess=$true)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidShouldContinueWithoutForce', '', Scope = 'Function', Target = 'CopyFileWithConflictDetection')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingConvertToSecureStringWithPlainText', '', Scope = 'Function', Target = 'ProcessParameter')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope = 'Function', Target = 'CopyFileWithConflictDetection')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope = 'Function', Target = 'ProcessFile')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope = 'Function', Target = 'ProcessModifyFile')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope = 'Function', Target = 'ProcessNewModuleManifest')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope = 'Function', Target = 'ProcessRequireModule')]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Position = 0, Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -91,7 +91,8 @@ function Invoke-Plaster {
 
                 $name = $node.name
                 $type = $node.type
-                $prompt = if ($node.prompt) { $node.prompt } else { $LocalizedData.MissingParameterPrompt_F1 -f $name }
+                $prompt = if ($node.prompt) { $node.prompt }
+                else { $LocalizedData.MissingParameterPrompt_F1 -f $name }
 
                 if (!$name -or !$type) { continue }
 
@@ -113,19 +114,20 @@ function Invoke-Plaster {
                         $setValues = New-Object string[] $choiceNodes.Count
                         $i = 0
 
-                        foreach ($choiceNode in $choiceNodes){
+                        foreach ($choiceNode in $choiceNodes) {
                             $setValues[$i++] = $choiceNode.value
                         }
 
                         $validateSetAttr = New-Object System.Management.Automation.ValidateSetAttribute $setValues
                         $attributeCollection.Add($validateSetAttr)
-                        $type = if ($type -eq 'multichoice') { [string[]] } else { [string] }
+                        $type = if ($type -eq 'multichoice') { [string[]] }
+                        else { [string] }
                         $param = New-Object System.Management.Automation.RuntimeDefinedParameter `
                                      -ArgumentList ($name, $type, $attributeCollection)
                         break
                     }
 
-                    default { throw ($LocalizedData.UnrecognizedParameterType_F2 -f $type,$name) }
+                    default { throw ($LocalizedData.UnrecognizedParameterType_F2 -f $type, $name) }
                 }
 
                 $paramDictionary.Add($name, $param)
@@ -199,7 +201,8 @@ function Invoke-Plaster {
                 TemplatePath = $templateAbsolutePath
                 DestinationPath = $destinationAbsolutePath
                 Success = $false
-                TemplateType = if ($manifest.plasterManifest.templateType) {$manifest.plasterManifest.templateType} else {'Unspecified'}
+                TemplateType = if ($manifest.plasterManifest.templateType) {$manifest.plasterManifest.templateType}
+                else {'Unspecified'}
                 CreatedFiles = [string[]]@()
                 UpdatedFiles = [string[]]@()
                 MissingModules = [string[]]@()
@@ -234,41 +237,41 @@ function Invoke-Plaster {
             $iss.LanguageMode = [System.Management.Automation.PSLanguageMode]::ConstrainedLanguage
             $iss.DisableFormatUpdates = $true
 
-            $sspe = New-Object System.Management.Automation.Runspaces.SessionStateProviderEntry 'Environment',([Microsoft.PowerShell.Commands.EnvironmentProvider]),$null
+            $sspe = New-Object System.Management.Automation.Runspaces.SessionStateProviderEntry 'Environment', ([Microsoft.PowerShell.Commands.EnvironmentProvider]), $null
             $iss.Providers.Add($sspe)
 
-            $sspe = New-Object System.Management.Automation.Runspaces.SessionStateProviderEntry 'FileSystem',([Microsoft.PowerShell.Commands.FileSystemProvider]),$null
+            $sspe = New-Object System.Management.Automation.Runspaces.SessionStateProviderEntry 'FileSystem', ([Microsoft.PowerShell.Commands.FileSystemProvider]), $null
             $iss.Providers.Add($sspe)
 
-            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Content',([Microsoft.PowerShell.Commands.GetContentCommand]),$null
+            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Content', ([Microsoft.PowerShell.Commands.GetContentCommand]), $null
             $iss.Commands.Add($ssce)
 
-            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Date',([Microsoft.PowerShell.Commands.GetDateCommand]),$null
+            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Date', ([Microsoft.PowerShell.Commands.GetDateCommand]), $null
             $iss.Commands.Add($ssce)
 
-            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-ChildItem',([Microsoft.PowerShell.Commands.GetChildItemCommand]),$null
+            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-ChildItem', ([Microsoft.PowerShell.Commands.GetChildItemCommand]), $null
             $iss.Commands.Add($ssce)
 
-            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Item',([Microsoft.PowerShell.Commands.GetItemCommand]),$null
+            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Item', ([Microsoft.PowerShell.Commands.GetItemCommand]), $null
             $iss.Commands.Add($ssce)
 
-            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-ItemProperty',([Microsoft.PowerShell.Commands.GetItemPropertyCommand]),$null
+            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-ItemProperty', ([Microsoft.PowerShell.Commands.GetItemPropertyCommand]), $null
             $iss.Commands.Add($ssce)
 
-            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Module',([Microsoft.PowerShell.Commands.GetModuleCommand]),$null
+            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Module', ([Microsoft.PowerShell.Commands.GetModuleCommand]), $null
             $iss.Commands.Add($ssce)
 
-            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Variable',([Microsoft.PowerShell.Commands.GetVariableCommand]),$null
+            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Get-Variable', ([Microsoft.PowerShell.Commands.GetVariableCommand]), $null
             $iss.Commands.Add($ssce)
 
-            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Test-Path',([Microsoft.PowerShell.Commands.TestPathCommand]),$null
+            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Test-Path', ([Microsoft.PowerShell.Commands.TestPathCommand]), $null
             $iss.Commands.Add($ssce)
 
-            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Out-String',([Microsoft.PowerShell.Commands.OutStringCommand]),$null
+            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Out-String', ([Microsoft.PowerShell.Commands.OutStringCommand]), $null
             $iss.Commands.Add($ssce)
 
             $scopedItemOptions = [System.Management.Automation.ScopedItemOptions]::AllScope
-            $plasterVars = Get-Variable -Name PLASTER_*,PSVersionTable
+            $plasterVars = Get-Variable -Name PLASTER_*, PSVersionTable
             if (Test-Path Variable:\IsLinux) {
                 $plasterVars += Get-Variable -Name IsLinux
             }
@@ -280,7 +283,7 @@ function Invoke-Plaster {
             }
             foreach ($var in $plasterVars) {
                 $ssve = New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry `
-                            $var.Name,$var.Value,$var.Description,$scopedItemOptions
+                            $var.Name, $var.Value, $var.Description, $scopedItemOptions
                 $iss.Variables.Add($ssve)
             }
 
@@ -310,13 +313,13 @@ function Invoke-Plaster {
                     $res
                 }
                 catch {
-                    throw ($LocalizedData.ExpressionInvalid_F2 -f $Expression,$_)
+                    throw ($LocalizedData.ExpressionInvalid_F2 -f $Expression, $_)
                 }
 
                 # Check for non-terminating errors.
                 if ($powershell.Streams.Error.Count -gt 0) {
                     $err = $powershell.Streams.Error[0]
-                    throw ($LocalizedData.ExpressionNonTermErrors_F2 -f $Expression,$err)
+                    throw ($LocalizedData.ExpressionNonTermErrors_F2 -f $Expression, $err)
                 }
             }
             finally {
@@ -339,7 +342,7 @@ function Invoke-Plaster {
                 [string]$res[0]
             }
             catch {
-                throw ($LocalizedData.InterpolationError_F3 -f $Value.Trim(),$Location,$_)
+                throw ($LocalizedData.InterpolationError_F3 -f $Value.Trim(), $Location, $_)
             }
         }
 
@@ -356,7 +359,7 @@ function Invoke-Plaster {
                 [bool]$res[0]
             }
             catch {
-                throw ($LocalizedData.ExpressionInvalidCondition_F3 -f $Expression,$Location,$_)
+                throw ($LocalizedData.ExpressionInvalidCondition_F3 -f $Expression, $Location, $_)
             }
         }
 
@@ -373,7 +376,7 @@ function Invoke-Plaster {
                 [string]$res[0]
             }
             catch {
-                throw ($LocalizedData.ExpressionExecError_F2 -f $Location,$_)
+                throw ($LocalizedData.ExpressionExecError_F2 -f $Location, $_)
             }
         }
 
@@ -390,12 +393,12 @@ function Invoke-Plaster {
                 [string[]]$res
             }
             catch {
-                throw ($LocalizedData.ExpressionExecError_F2 -f $Location,$_)
+                throw ($LocalizedData.ExpressionExecError_F2 -f $Location, $_)
             }
         }
 
         function GetErrorLocationFileAttrVal([string]$ElementName, [string]$AttributeName) {
-            $LocalizedData.ExpressionErrorLocationFile_F2 -f $ElementName,$AttributeName
+            $LocalizedData.ExpressionErrorLocationFile_F2 -f $ElementName, $AttributeName
         }
 
         function GetErrorLocationModifyAttrVal([string]$AttributeName) {
@@ -407,11 +410,11 @@ function Invoke-Plaster {
         }
 
         function GetErrorLocationParameterAttrVal([string]$ParameterName, [string]$AttributeName) {
-            $LocalizedData.ExpressionErrorLocationParameter_F2 -f $ParameterName,$AttributeName
+            $LocalizedData.ExpressionErrorLocationParameter_F2 -f $ParameterName, $AttributeName
         }
 
         function GetErrorLocationRequireModuleAttrVal([string]$ModuleName, [string]$AttributeName) {
-            $LocalizedData.ExpressionErrorLocationRequireModule_F2 -f $ModuleName,$AttributeName
+            $LocalizedData.ExpressionErrorLocationRequireModule_F2 -f $ModuleName, $AttributeName
         }
 
         function ConvertToDestinationRelativePath($Path) {
@@ -425,7 +428,7 @@ function Invoke-Plaster {
                 throw ($LocalizedData.ErrorPathMustBeUnderDestPath_F2 -f $fullPath, $fullDestPath)
             }
 
-            $fullPath.Substring($fullDestPath.Length).TrimStart('\','/')
+            $fullPath.Substring($fullDestPath.Length).TrimStart('\', '/')
         }
 
         function VerifyPathIsUnderDestinationPath([ValidateNotNullOrEmpty()][string]$FullPath) {
@@ -445,7 +448,7 @@ function Invoke-Plaster {
 
         function WriteContentWithEncoding([string]$path, [string[]]$content, [string]$encoding) {
             if ($encoding -match '-nobom') {
-                $encoding,$dummy = $encoding -split '-'
+                $encoding, $dummy = $encoding -split '-'
 
                 $noBomEncoding = $null
                 switch ($encoding) {
@@ -478,11 +481,11 @@ function Invoke-Plaster {
         }
 
         function GetMaxOperationLabelLength {
-            ($LocalizedData.OpCreate,   $LocalizedData.OpIdentical,
-             $LocalizedData.OpConflict, $LocalizedData.OpForce,
-             $LocalizedData.OpMissing,  $LocalizedData.OpModify,
-             $LocalizedData.OpUpdate,   $LocalizedData.OpVerify |
-                 Measure-Object -Property Length -Maximum).Maximum
+            ($LocalizedData.OpCreate, $LocalizedData.OpIdentical,
+                $LocalizedData.OpConflict, $LocalizedData.OpForce,
+                $LocalizedData.OpMissing, $LocalizedData.OpModify,
+                $LocalizedData.OpUpdate, $LocalizedData.OpVerify |
+                    Measure-Object -Property Length -Maximum).Maximum
         }
 
         function WriteOperationStatus($operation, $message) {
@@ -496,7 +499,7 @@ function Invoke-Plaster {
             foreach ($msg in $Message) {
                 $lines = $msg -split "`n"
                 foreach ($line in $lines) {
-                    Write-Host ("{0,$maxLen} {1}" -f "",$line)
+                    Write-Host ("{0,$maxLen} {1}" -f "", $line)
                 }
             }
         }
@@ -516,8 +519,7 @@ function Invoke-Plaster {
 
             if (Test-Path -LiteralPath $gitConfigPath) {
                 $matches = Select-String -LiteralPath $gitConfigPath -Pattern "\s+$name\s+=\s+(.+)$"
-                if (@($matches).Count -gt 0)
-                {
+                if (@($matches).Count -gt 0) {
                     $matches.Matches.Groups[1].Value
                 }
             }
@@ -535,22 +537,22 @@ function Invoke-Plaster {
         }
 
         function PromptForChoice([string]$ParameterName, [ValidateNotNull()]$ChoiceNodes, [string]$prompt,
-                                 [int[]]$defaults, [switch]$IsMultiChoice) {
+            [int[]]$defaults, [switch]$IsMultiChoice) {
             $choices = New-Object 'System.Collections.ObjectModel.Collection[System.Management.Automation.Host.ChoiceDescription]'
             $values = New-Object object[] $ChoiceNodes.Count
             $i = 0
 
             foreach ($choiceNode in $ChoiceNodes) {
                 $label = InterpolateAttributeValue $choiceNode.label (GetErrorLocationParameterAttrVal $ParameterName label)
-                $help  = InterpolateAttributeValue $choiceNode.help  (GetErrorLocationParameterAttrVal $ParameterName help)
+                $help = InterpolateAttributeValue $choiceNode.help  (GetErrorLocationParameterAttrVal $ParameterName help)
                 $value = InterpolateAttributeValue $choiceNode.value (GetErrorLocationParameterAttrVal $ParameterName value)
 
-                $choice = New-Object System.Management.Automation.Host.ChoiceDescription -Arg $label,$help
+                $choice = New-Object System.Management.Automation.Host.ChoiceDescription -Arg $label, $help
                 $choices.Add($choice)
                 $values[$i++] = $value
             }
 
-            $retval = [PSCustomObject]@{Values=@(); Indices=@()}
+            $retval = [PSCustomObject]@{Values = @(); Indices = @()}
 
             if ($IsMultiChoice) {
                 $selections = $Host.UI.PromptForChoice('', $prompt, $choices, $defaults)
@@ -578,11 +580,11 @@ function Invoke-Plaster {
         # the latest Plaster variables.
         function SetPlasterVariable() {
             param(
-                [Parameter(Mandatory=$true)]
+                [Parameter(Mandatory = $true)]
                 [ValidateNotNullOrEmpty()]
                 [string]$Name,
 
-                [Parameter(Mandatory=$true)]
+                [Parameter(Mandatory = $true)]
                 $Value,
 
                 [Parameter()]
@@ -592,7 +594,8 @@ function Invoke-Plaster {
 
             # Variables created from a <parameter> in the Plaster manifset are prefixed PLASTER_PARAM all others
             # are just PLASTER_.
-            $variableName = if ($IsParam) { "PLASTER_PARAM_$Name" } else { "PLASTER_$Name" }
+            $variableName = if ($IsParam) { "PLASTER_PARAM_$Name" }
+            else { "PLASTER_$Name" }
 
             Set-Variable -Name $variableName -Value $Value -Scope Script -WhatIf:$false
 
@@ -623,7 +626,7 @@ function Invoke-Plaster {
 
                     if (($store -eq 'encrypted') -and ($default -is [System.Security.SecureString])) {
                         try {
-                            $cred = New-Object -TypeName PSCredential -ArgumentList 'jsbplh',$default
+                            $cred = New-Object -TypeName PSCredential -ArgumentList 'jsbplh', $default
                             $default = $cred.GetNetworkCredential().Password
                             $PSCmdlet.WriteDebug("Unencrypted default value for parameter '$name'.")
                         }
@@ -710,7 +713,7 @@ function Invoke-Plaster {
                         $OFS = ","
                         $valueToStore = "$($selections.Indices)"
                     }
-                    default  { throw ($LocalizedData.UnrecognizedParameterType_F2 -f $type, $Node.LocalName) }
+                    default { throw ($LocalizedData.UnrecognizedParameterType_F2 -f $type, $Node.LocalName) }
                 }
 
                 # If parameter specifies that user's input be stored as the default value,
@@ -738,12 +741,12 @@ function Invoke-Plaster {
             $nonewline = $Node.nonewline -eq 'true'
 
             # Eliminate whitespace before and after the text that just happens to get inserted because you want
-            # the text on different lines than the start/end element tags.
-            $trimmedText = $text -replace '^[ \t]*\n','' -replace '\n[ \t]*$',''
+            # the text on different lines than the start/end element Tags.
+            $trimmedText = $text -replace '^[ \t]*\n', '' -replace '\n[ \t]*$', ''
 
-            $condition  = $Node.condition
+            $condition = $Node.condition
             if ($condition -and !(EvaluateConditionAttribute $condition "'<$($Node.LocalName)>'")) {
-                $debugText = $trimmedText -replace '\r|\n',' '
+                $debugText = $trimmedText -replace '\r|\n', ' '
                 $maxLength = [Math]::Min(40, $debugText.Length)
                 $PSCmdlet.WriteDebug("Skipping message '$($debugText.Substring(0, $maxLength))', condition evaluated to false.")
                 return
@@ -754,39 +757,98 @@ function Invoke-Plaster {
 
         function CopyModuleManifestPropertyToHashtable([PSModuleInfo]$oldModuleManifest, [hashtable]$hashtable, [string[]]$Property) {
             foreach ($prop in $Property) {
-                if ($oldModuleManifest.$prop) {
-                    $hashtable["$prop"] = $oldModuleManifest.$prop
+                # if the property exists in the old manifest file but not in our existing hash then add it.
+                if (($oldModuleManifest.$prop) -and ($null -eq $hashtable.$prop)) {
+                    if (($prop -eq 'Tags') -and (($oldModuleManifest.$prop).Count -gt 0)) {
+                        $hashtable[$prop] = @($oldModuleManifest.$prop)
+                    }
+                    else {
+                        $hashtable[$prop] = ($oldModuleManifest.$prop).ToString()
+                    }
                 }
             }
         }
 
         function ProcessNewModuleManifest([ValidateNotNull()]$Node) {
-            $moduleVersion = InterpolateAttributeValue $Node.moduleVersion (GetErrorLocationNewModManifestAttrVal moduleVersion)
-            $rootModule = InterpolateAttributeValue $Node.rootModule (GetErrorLocationNewModManifestAttrVal rootModule)
-            $author = InterpolateAttributeValue $Node.author (GetErrorLocationNewModManifestAttrVal author)
-            $companyName = InterpolateAttributeValue $Node.companyName (GetErrorLocationNewModManifestAttrVal companyName)
-            $description = InterpolateAttributeValue $Node.description (GetErrorLocationNewModManifestAttrVal description)
-            $dstRelPath = InterpolateAttributeValue $Node.destination (GetErrorLocationNewModManifestAttrVal destination)
-
-            # We could choose to not check this if the condition eval'd to false
-            # but I think it is better to let the template author know they've broken the
-            # rules for any of the file directives (not just the ones they're testing/enabled).
-            if ([System.IO.Path]::IsPathRooted($dstRelPath)) {
-                throw ($LocalizedData.ErrorPathMustBeRelativePath_F2 -f $dstRelPath,$Node.LocalName)
-            }
-
-            $dstPath = $PSCmdlet.GetUnresolvedProviderPathFromPSPath((Join-Path $DestinationPath $dstRelPath))
-
-            $condition  = $Node.condition
+            # First if a condition is defined and not met then there is nothing to do
+            $condition = $Node.condition
             if ($condition -and !(EvaluateConditionAttribute $condition "'<$($Node.LocalName)>'")) {
                 $PSCmdlet.WriteDebug("Skipping module manifest generation for '$dstPath', condition evaluated to false.")
                 return
             }
 
-            $encoding = $Node.encoding
+            # Get defined properties in the manifest
+            $DefinedProperties = @($node | Get-Member -Type:Property).Name
+
+            # Our future hash for splatting the new-modulemanifest command
+            $newModuleManifestParams = @{}
+
+            # Pull all the new-modulemanifest parameters to account for future version changes and such
+            $CmdParams = (Get-Command New-ModuleManifest).Parameters
+
+            # Some ignored parameters that we either overwrite or will not be splatting
+            $IgnoredManifestVals = @('Path', 'PrivateData', 'PassThru')
+
+            # Get all non-advanced function parameters that new-modulemanifest uses
+            $ValidModuleManifestParams = $CmdParams.keys | ForEach-Object {
+                if (($CmdParams[$_].Attributes.TypeId.Name -notcontains 'AliasAttribute') -and ($IgnoredManifestVals -notcontains $_)) {
+                    $_
+                }
+            }
+
+            # Create a hash of parameter types so we know how to process module manifest entries (as arrays or strings)
+            $paramTypes = @{}
+            $ValidModuleManifestParams | ForEach-Object {
+                $ParamTypes[$_] = $CmdParams[$_].ParameterType.BaseType.ToString()
+            }
+
+            # Now go through all the defined module properties in the manifest, get the value, and build the splat
+            ForEach ($ModProp in $DefinedProperties) {
+                $PSCmdlet.WriteDebug("Determining how to handle the modulemanifest property - $ModProp.")
+                $PropVal = InterpolateAttributeValue $Node.$ModProp (GetErrorLocationNewModManifestAttrVal $ModProp)
+                # We are only concerned about the values which align with a new-modulemanifest parameter
+                if (![string]::IsNullOrWhiteSpace($PropVal) -and ($ValidModuleManifestParams -contains $ModProp)) {
+                    # take action based on the type of parameter being splatted
+                    switch ($ParamTypes[$ModProp]) {
+                        'System.Array' {
+                            # If this is an array type then assume it is a comma separated list of values
+                            $newModuleManifestParams[$ModProp] = @($PropVal -split ',' | ForEach-Object {$_.trim()})
+                        }
+                        Default {
+                            # Otherwise just pass it on as a string
+                            # We could process the enum for ProcessorArchitecture and such separately I suppose.
+                            $newModuleManifestParams[$ModProp] = $PropVal
+                        }
+                    }
+                }
+                else {
+                    # Process everything else accordingly (leave logic for future non-parameter based modulemanifest schema additions)
+                    switch ($ModProp) {
+                        'destination' {
+                            $dstRelPath = $PropVal
+                        }
+                        'encoding' {
+                            $encoding = $Node.encoding
+                        }
+                        'openInEditor' {}
+                        Default {}
+                    }
+                }
+            }
+
+            # No encoding defined? Make it default then.
             if (!$encoding) {
                 $encoding = $DefaultEncoding
             }
+
+            # We could choose to not check this if the condition eval'd to false
+            # but I think it is better to let the template author know they've broken the
+            # rules for any of the file directives (not just the ones they're testing/enabled).
+            if ([System.IO.Path]::IsPathRooted($dstRelPath)) {
+                throw ($LocalizedData.ErrorPathMustBeRelativePath_F2 -f $dstRelPath, $Node.LocalName)
+            }
+
+            $dstPath = $PSCmdlet.GetUnresolvedProviderPathFromPSPath((Join-Path $DestinationPath $dstRelPath))
 
             if ($PSCmdlet.ShouldProcess($dstPath, $LocalizedData.ShouldProcessNewModuleManifest)) {
                 $manifestDir = Split-Path $dstPath -Parent
@@ -796,35 +858,24 @@ function Invoke-Plaster {
                     New-Item $manifestDir -ItemType Directory > $null
                 }
 
-                $newModuleManifestParams = @{}
-
                 # If there is an existing module manifest, load it so we can reuse old values not specified by
                 # template.
                 if (Test-Path -LiteralPath $dstPath) {
                     $oldModuleManifest = Test-ModuleManifest -Path $dstPath -ErrorAction SilentlyContinue
                     if ($? -and $oldModuleManifest) {
-                        $props = 'Guid', 'Description', 'DefaultCommandPrefix', 'RootModule', 'AliasesToExport',
-                                 'CmdletsToExport', 'DscResourcesToExport', 'VariablesToExport',
-                                 'FormatsToProcess', 'TypesToProcess', 'ScriptsToProcess'
-
-                        CopyModuleManifestPropertyToHashtable $oldModuleManifest $newModuleManifestParams $props
+                        $PSCmdlet.WriteDebug("We found an existing manifest file. Pulling in all values not defined in the Plaster manifest file.")
+                        # Get a list of properties that have values already from the old manifest but
+                        # are not defined in the plaster manifest and are also valid new-modulemanifest parameters
+                        $props = @(($oldModuleManifest | Get-member -Type 'Property' |
+                                    Where-Object {($null -ne $oldModuleManifest.($_.Name)) -and
+                                    ($_.Name -ne 'PSData') -and
+                                    (-not [string]::IsNullOrEmpty(($oldModuleManifest))) -and
+                                    ($ValidModuleManifestParams -contains $_.Name)}).Name |
+                                Where-Object {$DefinedProperties -notcontains $_})
+                        if ($props.count -gt 0) {
+                            CopyModuleManifestPropertyToHashtable $oldModuleManifest $newModuleManifestParams $props
+                        }
                     }
-                }
-
-                if (![string]::IsNullOrWhiteSpace($moduleVersion)) {
-                    $newModuleManifestParams['ModuleVersion'] = $moduleVersion
-                }
-                if (![string]::IsNullOrWhiteSpace($rootModule)) {
-                    $newModuleManifestParams['RootModule'] = $rootModule
-                }
-                if (![string]::IsNullOrWhiteSpace($author)) {
-                    $newModuleManifestParams['Author'] = $author
-                }
-                if (![string]::IsNullOrWhiteSpace($companyName)) {
-                    $newModuleManifestParams['CompanyName'] = $companyName
-                }
-                if (![string]::IsNullOrWhiteSpace($description)) {
-                    $newModuleManifestParams['Description'] = $description
                 }
 
                 $tempFile = $null
@@ -893,14 +944,14 @@ function Invoke-Plaster {
         }
 
         function NewFileSystemCopyInfo([string]$srcPath, [string]$dstPath) {
-            [PSCustomObject]@{SrcFileName=$srcPath; DstFileName=$dstPath}
+            [PSCustomObject]@{SrcFileName = $srcPath; DstFileName = $dstPath}
         }
 
         function ExpandFileSourceSpec([string]$srcRelPath, [string]$dstRelPath) {
             $srcPath = Join-Path $templateAbsolutePath $srcRelPath
             $dstPath = Join-Path $destinationAbsolutePath $dstRelPath
 
-            if ($srcRelPath.IndexOfAny([char[]]('*','?')) -lt 0) {
+            if ($srcRelPath.IndexOfAny([char[]]('*', '?')) -lt 0) {
                 # No wildcard spec in srcRelPath so return info on single file.
                 # Also, if dstRelPath is empty, then use source rel path.
                 if (!$dstRelPath) {
@@ -921,7 +972,7 @@ function Invoke-Plaster {
                 $gciParams['Recurse'] = $true
             }
             else {
-                if ($leaf.IndexOfAny([char[]]('*','?')) -ge 0) {
+                if ($leaf.IndexOfAny([char[]]('*', '?')) -ge 0) {
                     $gciParams['Filter'] = $leaf
                 }
 
@@ -948,7 +999,7 @@ function Invoke-Plaster {
             $gciParams.Remove('File')
             $gciParams['Directory'] = $true
             $dirs = @(Microsoft.PowerShell.Management\Get-ChildItem @gciParams |
-                          Where-Object {$_.GetFileSystemInfos().Length -eq 0})
+                    Where-Object {$_.GetFileSystemInfos().Length -eq 0})
             foreach ($dir in $dirs) {
                 $dirSrcPath = $dir.FullName
                 $relPath = $dirSrcPath.Substring($srcRelRootPathLength)
@@ -990,7 +1041,7 @@ function Invoke-Plaster {
                 elseif ($Force) {
                     $operation = $LocalizedData.OpForce
                 }
-                else  {
+                else {
                     $operation = $LocalizedData.OpConflict
                 }
             }
@@ -1012,9 +1063,9 @@ function Invoke-Plaster {
                     $templateCreatedFiles[$DstPath] = $null
                 }
                 elseif ($Force -or $PSCmdlet.ShouldContinue(($LocalizedData.OverwriteFile_F1 -f $DstPath),
-                                                             $LocalizedData.FileConflict,
-                                                             [ref]$fileConflictConfirmYesToAll,
-                                                             [ref]$fileConflictConfirmNoToAll)) {
+                        $LocalizedData.FileConflict,
+                        [ref]$fileConflictConfirmYesToAll,
+                        [ref]$fileConflictConfirmNoToAll)) {
                     $backupFilename = NewBackupFilename $DstPath
                     Copy-Item -LiteralPath $DstPath -Destination $backupFilename
                     Copy-Item -LiteralPath $SrcPath -Destination $DstPath
@@ -1039,14 +1090,14 @@ function Invoke-Plaster {
             # but I think it is better to let the template author know they've broken the
             # rules for any of the file directives (not just the ones they're testing/enabled).
             if ([System.IO.Path]::IsPathRooted($srcRelPath)) {
-                throw ($LocalizedData.ErrorPathMustBeRelativePath_F2 -f $srcRelPath,$Node.LocalName)
+                throw ($LocalizedData.ErrorPathMustBeRelativePath_F2 -f $srcRelPath, $Node.LocalName)
             }
 
             if ([System.IO.Path]::IsPathRooted($dstRelPath)) {
-                throw ($LocalizedData.ErrorPathMustBeRelativePath_F2 -f $dstRelPath,$Node.LocalName)
+                throw ($LocalizedData.ErrorPathMustBeRelativePath_F2 -f $dstRelPath, $Node.LocalName)
             }
 
-            $condition  = $Node.condition
+            $condition = $Node.condition
             if ($condition -and !(EvaluateConditionAttribute $condition "'<$($Node.LocalName)>'")) {
                 $PSCmdlet.WriteDebug("Skipping $($Node.localName) '$srcRelPath' -> '$dstRelPath', condition evaluated to false.")
                 return
@@ -1077,7 +1128,7 @@ function Invoke-Plaster {
                     if (!(Test-Path -LiteralPath $dstPath)) {
                         if ($PSCmdlet.ShouldProcess($parentDir, $LocalizedData.ShouldProcessCreateDir)) {
                             WriteOperationStatus $LocalizedData.OpCreate `
-                                ($dstRelPath.TrimEnd(([char]'\'),([char]'/')) + [System.IO.Path]::DirectorySeparatorChar)
+                                ($dstRelPath.TrimEnd(([char]'\'), ([char]'/')) + [System.IO.Path]::DirectorySeparatorChar)
                             New-Item -Path $dstPath -ItemType Directory > $null
                         }
                     }
@@ -1105,22 +1156,22 @@ function Invoke-Plaster {
                         # Eval script expression delimiters
                         if ($content -and ($content.Count -gt 0)) {
                             $newContent = [regex]::Replace($content, '(<%=)(.*?)(%>)', {
-                                param($match)
-                                $expr = $match.groups[2].value
-                                $res = EvaluateExpression $expr "templateFile '$srcRelPath'"
-                                $PSCmdlet.WriteDebug("Replacing '$expr' with '$res' in contents of template file '$srcPath'")
-                                $res
-                            },  @('IgnoreCase'))
+                                    param($match)
+                                    $expr = $match.groups[2].value
+                                    $res = EvaluateExpression $expr "templateFile '$srcRelPath'"
+                                    $PSCmdlet.WriteDebug("Replacing '$expr' with '$res' in contents of template file '$srcPath'")
+                                    $res
+                                }, @('IgnoreCase'))
 
                             # Eval script block delimiters
                             $newContent = [regex]::Replace($newContent, '(^<%)(.*?)(^%>)', {
-                                param($match)
-                                $expr = $match.groups[2].value
-                                $res = EvaluateScript $expr "templateFile '$srcRelPath'"
-                                $res = $res -join [System.Environment]::NewLine
-                                $PSCmdlet.WriteDebug("Replacing '$expr' with '$res' in contents of template file '$srcPath'")
-                                $res
-                            },  @('IgnoreCase', 'SingleLine', 'MultiLine'))
+                                    param($match)
+                                    $expr = $match.groups[2].value
+                                    $res = EvaluateScript $expr "templateFile '$srcRelPath'"
+                                    $res = $res -join [System.Environment]::NewLine
+                                    $PSCmdlet.WriteDebug("Replacing '$expr' with '$res' in contents of template file '$srcPath'")
+                                    $res
+                                }, @('IgnoreCase', 'SingleLine', 'MultiLine'))
 
                             $srcPath = $tempFile = [System.IO.Path]::GetTempFileName()
                             $PSCmdlet.WriteDebug("Created temp file for expanded templateFile - $tempFile")
@@ -1154,7 +1205,7 @@ function Invoke-Plaster {
             # but I think it is better to let the template author know they've broken the
             # rules for any of the file directives (not just the ones they're testing/enabled).
             if ([System.IO.Path]::IsPathRooted($path)) {
-                throw ($LocalizedData.ErrorPathMustBeRelativePath_F2 -f $path,$Node.LocalName)
+                throw ($LocalizedData.ErrorPathMustBeRelativePath_F2 -f $path, $Node.LocalName)
             }
 
             $filePath = $PSCmdlet.GetUnresolvedProviderPathFromPSPath((Join-Path $DestinationPath $path))
@@ -1194,7 +1245,7 @@ function Invoke-Plaster {
 
                     switch ($childNode.LocalName) {
                         'replace' {
-                            $condition  = $childNode.condition
+                            $condition = $childNode.condition
                             if ($condition -and !(EvaluateConditionAttribute $condition "'<$($Node.LocalName)><$($childNode.LocalName)>'")) {
                                 $PSCmdlet.WriteDebug("Skipping $($Node.LocalName) $($childNode.LocalName) of '$filePath', condition evaluated to false.")
                                 continue
@@ -1222,7 +1273,7 @@ function Invoke-Plaster {
                                 $substitute = InterpolateAttributeValue $substitute (GetErrorLocationModifyAttrVal substitute)
                             }
 
-                            $fileContent = $fileContent -replace $original,$substitute
+                            $fileContent = $fileContent -replace $original, $substitute
 
                             # Update the Plaster (non-parameter) variable's value in this and the constrained runspace.
                             SetPlasterVariable -Name FileContent -Value $fileContent -IsParam $false
@@ -1323,10 +1374,11 @@ function Invoke-Plaster {
 
             $module = Get-Module @getModuleParams
 
-            $moduleDesc = if ($versionRequirements) { "${name}:$versionRequirements" } else { $name }
+            $moduleDesc = if ($versionRequirements) { "${name}:$versionRequirements" }
+            else { $name }
 
             if ($null -eq $module) {
-                WriteOperationStatus $LocalizedData.OpMissing ($LocalizedData.RequireModuleMissing_F2 -f $name,$versionRequirements)
+                WriteOperationStatus $LocalizedData.OpMissing ($LocalizedData.RequireModuleMissing_F2 -f $name, $versionRequirements)
                 if ($message) {
                     WriteOperationAdditionalStatus $message
                 }
@@ -1336,7 +1388,7 @@ function Invoke-Plaster {
             }
             else {
                 if ($PSVersionTable.PSVersion.Major -gt 3) {
-                    WriteOperationStatus $LocalizedData.OpVerify ($LocalizedData.RequireModuleVerified_F2 -f $name,$versionRequirements)
+                    WriteOperationStatus $LocalizedData.OpVerify ($LocalizedData.RequireModuleVerified_F2 -f $name, $versionRequirements)
                 }
                 else {
                     # On V3, we have to the version matching with the results that Get-Module return.
@@ -1352,13 +1404,13 @@ function Invoke-Plaster {
                         ($minimumVersion -and ($installedVersion -lt $minimumVersion)) -or
                         ($maximumVersion -and ($installedVersion -gt $maximumVersion))) {
 
-                        WriteOperationStatus $LocalizedData.OpMissing ($LocalizedData.RequireModuleMissing_F2 -f $name,$versionRequirements)
+                        WriteOperationStatus $LocalizedData.OpMissing ($LocalizedData.RequireModuleMissing_F2 -f $name, $versionRequirements)
                         if ($PassThru) {
                             $InvokePlasterInfo.MissingModules += $moduleDesc
                         }
                     }
                     else {
-                        WriteOperationStatus $LocalizedData.OpVerify ($LocalizedData.RequireModuleVerified_F2 -f $name,$versionRequirements)
+                        WriteOperationStatus $LocalizedData.OpVerify ($LocalizedData.RequireModuleVerified_F2 -f $name, $versionRequirements)
                     }
                 }
             }
@@ -1371,8 +1423,8 @@ function Invoke-Plaster {
             foreach ($node in $manifest.plasterManifest.parameters.ChildNodes) {
                 if ($node -isnot [System.Xml.XmlElement]) { continue }
                 switch ($node.LocalName) {
-                    'parameter'  { ProcessParameter $node }
-                    default      { throw ($LocalizedData.UnrecognizedParametersElement_F1 -f $node.LocalName) }
+                    'parameter' { ProcessParameter $node }
+                    default { throw ($LocalizedData.UnrecognizedParametersElement_F1 -f $node.LocalName) }
                 }
             }
 
@@ -1401,11 +1453,11 @@ function Invoke-Plaster {
 
                 switch -Regex ($node.LocalName) {
                     'file|templateFile' { ProcessFile $node; break }
-                    'message'           { ProcessMessage $node; break }
-                    'modify'            { ProcessModifyFile $node; break }
+                    'message' { ProcessMessage $node; break }
+                    'modify' { ProcessModifyFile $node; break }
                     'newModuleManifest' { ProcessNewModuleManifest $node; break }
-                    'requireModule'     { ProcessRequireModule $node; break }
-                    default             { throw ($LocalizedData.UnrecognizedContentElement_F1 -f $node.LocalName) }
+                    'requireModule' { ProcessRequireModule $node; break }
+                    default { throw ($LocalizedData.UnrecognizedContentElement_F1 -f $node.LocalName) }
                 }
             }
 
@@ -1432,10 +1484,10 @@ function InitializePredefinedVariables([string]$TemplatePath, [string]$DestPath)
     # Always set these variables, even if the command has been run with -WhatIf
     $WhatIfPreference = $false
 
-    Set-Variable -Name PLASTER_TemplatePath -Value $TemplatePath.TrimEnd('\','/') -Scope Script
+    Set-Variable -Name PLASTER_TemplatePath -Value $TemplatePath.TrimEnd('\', '/') -Scope Script
 
     $destName = Split-Path -Path $DestPath -Leaf
-    Set-Variable -Name PLASTER_DestinationPath -Value $DestPath.TrimEnd('\','/') -Scope Script
+    Set-Variable -Name PLASTER_DestinationPath -Value $DestPath.TrimEnd('\', '/') -Scope Script
     Set-Variable -Name PLASTER_DestinationName -Value $destName -Scope Script
     Set-Variable -Name PLASTER_DirSepChar      -Value ([System.IO.Path]::DirectorySeparatorChar) -Scope Script
     Set-Variable -Name PLASTER_HostName        -Value $Host.Name -Scope Script

--- a/src/Plaster.psd1
+++ b/src/Plaster.psd1
@@ -52,9 +52,17 @@
     FunctionsToExport = @(
         'Invoke-Plaster'
         'New-PlasterManifest'
-        'Get-PlasterTemplate',
+        'Get-PlasterTemplate'
         'Test-PlasterManifest'
-        )
+        'Write-PlasterParameter'
+        'Write-PlasterManifestContent'
+        'Write-PlasterManifestContentRequireModule'
+        'Write-PlasterManifestContentNewModuleManifest'
+        'Write-PlasterManifestContentModify'
+        'Write-PlasterManifestContentMessage'
+        'Write-PlasterManifestContentTemplateFile'
+        'Write-PlasterManifestContentFile'
+    )
 
     # HelpInfo URI of this module
     # HelpInfoURI = ''

--- a/src/Plaster.psm1
+++ b/src/Plaster.psm1
@@ -98,5 +98,7 @@ else {
 . $PSScriptRoot\TestPlasterManifest.ps1
 . $PSScriptRoot\GetPlasterTemplate.ps1
 . $PSScriptRoot\InvokePlaster.ps1
+. $PSScriptRoot\WritePlasterParameter.ps1
+. $PSScriptRoot\WritePlasterManifestContent.ps1
 
 Export-ModuleMember -Function *-*

--- a/src/Schema/PlasterManifest-v1.xsd
+++ b/src/Schema/PlasterManifest-v1.xsd
@@ -448,6 +448,111 @@
                       <xs:documentation>Specifies the value of the RootModule property.</xs:documentation>
                     </xs:annotation>
                   </xs:attribute>
+                  <xs:attribute name="copyright" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Specifies the copyright for this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="tags" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Specifies the module tags.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="projectUri" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Specifies the project website.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="licenseUri" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Specifies the license website.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="iconUri" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Specifies the icon website.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="nestedModules" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Specifies nested modules.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="requiredModules" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Specifies required modules.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="typesToProcess" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Types to process for this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="formatsToProcess" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Formats to process for this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="scriptsToProcess" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Scripts to process for this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="requiredAssemblies" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Assemblies required for this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="fileList" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Files included in this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="moduleList" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Modules included in this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="functionsToExport" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Functions exported in this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="aliasesToExport" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Aliases exported in this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="variablesToExport" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Variables exported in this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="cmdletsToExport" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Cmdlets exported in this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="dscResourcesToExport" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>DSC resources exported in this module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="compatiblePSEditions" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Compatible PowerShell editions.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="helpInfoURI" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Help information website.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                  <xs:attribute name="defaultCommandPrefix" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Default command prefix for exported commands.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
                   <xs:attribute name="condition" type="ptd:condition"/>
                   <xs:attribute name="encoding" type="ptd:encoding" default="Default"/>
                   <xs:attribute name="openInEditor" type="ptd:openInEditor"/>

--- a/src/WritePlasterManifestContent.ps1
+++ b/src/WritePlasterManifestContent.ps1
@@ -1,0 +1,775 @@
+<#
+.SYNOPSIS
+A simple helper function to create a plaster message xml block
+.DESCRIPTION
+A simple helper function to create a plaster message xml block
+.PARAMETER Message
+The message to display
+.PARAMETER Condition
+The condition to match to display the message
+.PARAMETER NoNewLine
+The message will not include a newline at the end
+.EXAMPLE
+Write-PlasterManifestContentMessage -Message 'Building out your module and preparing the environment...' -NoNewLine
+.NOTES
+This only outputs a an xml string that needs to be combined as part of a larger content block to create your manifest file.
+#>
+function Write-PlasterManifestContentMessage {
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Message,
+        [Parameter(Position = 1)]
+        [string]$Condition,
+        [Parameter(Position = 2)]
+        [bool]$NoNewLine
+    )
+
+    process {
+        # Create a new XML File with config root node
+        $oXMLRoot = New-Object System.XML.XMLDocument
+
+        # New Node
+        $oXMLContent = $oXMLRoot.CreateElement('message')
+
+        # Set the message
+        $oXMLContent.InnerText = $Message
+
+        if (-not [string]::IsNullOrEmpty($Condition)) {
+            $oXMLContent.SetAttribute("condition", $Condition)
+        }
+        if ($NoNewLine) {
+            $oXMLContent.SetAttribute("noNewLine", 'true')
+        }
+
+        # Append as child to an existing node
+        $null = $oXMLRoot.appendChild($oXMLContent)
+
+        # Return the result
+        $oXMLRoot.InnerXML
+    }
+}
+
+<#
+.SYNOPSIS
+A simple helper function to create a plaster file xml block
+.DESCRIPTION
+A simple helper function to create a plaster file xml block.
+.PARAMETER Source
+Source file
+.PARAMETER Destination
+Destination file
+.PARAMETER Condition
+Used to determine whether this directive is executed
+.PARAMETER OpenInEditor
+Specifies whether the file should be opened in the editor (true) after scaffolding or not (false)
+.EXAMPLE
+TBD
+.NOTES
+This only outputs a an xml string that needs to be combined as part of a larger content block to create your manifest file.
+#>
+function Write-PlasterManifestContentFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Source,
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string]$Destination,
+        [Parameter(Position = 2)]
+        [string]$Condition,
+        [Parameter(Position = 3)]
+        [bool]$openInEditor
+    )
+
+    process {
+        # Create a new XML File with config root node
+        $oXMLRoot = New-Object System.XML.XMLDocument
+
+        # New Node
+        $oXMLContent = $oXMLRoot.CreateElement('file')
+
+        # Uses: source, destination, condition, openInEditor
+        $oXMLContent.SetAttribute("source", $Source)
+        $oXMLContent.SetAttribute("destination", $Destination)
+        if (-not [string]::IsNullOrEmpty($Condition)) {
+            $oXMLContent.SetAttribute("condition", $Condition)
+        }
+        if ($openInEditor) {
+            $oXMLContent.SetAttribute("openInEditor", 'true')
+        }
+
+        # Append as child to an existing node
+        $null = $oXMLRoot.appendChild($oXMLContent)
+
+        # Return the result
+        $oXMLRoot.InnerXML
+    }
+}
+
+<#
+.SYNOPSIS
+A simple helper function to create a plaster templatefile xml block
+.DESCRIPTION
+A simple helper function to create a plaster templatefile xml block.
+.PARAMETER Source
+Source file
+.PARAMETER Destination
+Destination file
+.PARAMETER Condition
+Used to determine whether this directive is executed
+.PARAMETER OpenInEditor
+Specifies whether the file should be opened in the editor (true) after scaffolding or not (false)
+.PARAMETER Encoding
+Encoding for created file
+.EXAMPLE
+TBD
+.NOTES
+This only outputs a an xml string that needs to be combined as part of a larger content block to create your manifest file.
+#>
+function Write-PlasterManifestContentTemplateFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Source,
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string]$Destination,
+        [Parameter(Position = 2)]
+        [string]$Condition,
+        [Parameter(Position = 3)]
+        [bool]$openInEditor,
+        [Parameter(Position = 4)]
+        [string]$Encoding
+    )
+
+    process {
+        # Create a new XML File with config root node
+        $oXMLRoot = New-Object System.XML.XMLDocument
+
+        # New Node
+        $oXMLContent = $oXMLRoot.CreateElement('templateFile')
+        $oXMLContent.SetAttribute("source", $Source)
+        $oXMLContent.SetAttribute("destination", $Destination)
+        if (-not [string]::IsNullOrEmpty($Condition)) {
+            $oXMLContent.SetAttribute("condition", $Condition)
+        }
+        if (-not [string]::IsNullOrEmpty($Encoding)) {
+            $oXMLContent.SetAttribute("encoding", $Encoding)
+        }
+        if ($openInEditor) {
+            $oXMLContent.SetAttribute("openInEditor", 'true')
+        }
+
+        # Append as child to an existing node
+        $null = $oXMLRoot.appendChild($oXMLContent)
+
+        # Return the result
+        $oXMLRoot.InnerXML
+    }
+}
+
+<#
+.SYNOPSIS
+A simple helper function to create a plaster newModuleManifest xml block
+.DESCRIPTION
+A simple helper function to create a plaster newModuleManifest xml block.
+.PARAMETER Destination
+Where the module manifest will be created. If it already exists then existing values will be resused if they are not defined in this content block
+.PARAMETER Condition
+Used to determine whether this directive is executed
+.PARAMETER OpenInEditor
+Specifies whether the file should be opened in the editor (true) after scaffolding or not (false)
+.PARAMETER Encoding
+Encoding for created file
+.PARAMETER author
+Module manifest author
+.PARAMETER companyName
+Module manifest company
+.PARAMETER description
+Module description
+.PARAMETER moduleVersion
+Module version
+.PARAMETER rootModule
+Root module for th emanifest
+.PARAMETER copyright
+Module manifest copyright
+.PARAMETER tags
+Module tags
+.PARAMETER projectUri
+Module project website
+.PARAMETER licenseUri
+Module license website
+.PARAMETER iconUri
+Module icon link
+.PARAMETER helpInfoUri
+Module help website
+.PARAMETER nestedModules
+Nested modules
+.PARAMETER requiredModules
+Required modules for the module manifest
+.PARAMETER typesToProcess
+Types to process for this module
+.PARAMETER formatsToProcess
+Formats to process for this module
+.PARAMETER scriptsToProcess
+Scripts to process for this module
+.PARAMETER requiredAssemblies
+Required assemblies for this module
+.PARAMETER fileList
+List of files for this module
+.PARAMETER moduleList
+List of modules for thid module
+.PARAMETER functionsToExport
+Functions to export for this module
+.PARAMETER aliasesToExport
+Aliases to export for th is module
+.PARAMETER variablesToExport
+Variables to export for this module
+.PARAMETER cmdletsToExport
+Cmdlets to export for this module
+.PARAMETER dscResourcesToExport
+DSC resources to export for this module
+.PARAMETER compatiblePSEditions
+Compatible versions of PowerShell for this module
+.PARAMETER defaultCommandPrefix
+Default prefix for commands exported from this module
+.EXAMPLE
+TBD
+.NOTES
+This only outputs a an xml string that needs to be combined as part of a larger content block to create your manifest file.
+.LINK
+https://github.com/PowerShell/Plaster/blob/master/docs/en-US/about_Plaster_CreatingAManifest.help.md
+#>
+function Write-PlasterManifestContentNewModuleManifest {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$destination,
+        [string]$condition,
+        [bool]$openInEditor,
+        [string]$encoding,
+        [string]$author,
+        [string]$companyName,
+        [string]$description,
+        [string]$moduleVersion,
+        [string]$rootModule,
+        [string]$copyright,
+        [string]$tags,
+        [string]$projectUri,
+        [string]$licenseUri,
+        [string]$iconUri,
+        [string]$helpInfoUri,
+        [string]$nestedModules,
+        [string]$requiredModules,
+        [string]$typesToProcess,
+        [string]$formatsToProcess,
+        [string]$scriptsToProcess,
+        [string]$requiredAssemblies,
+        [string]$fileList,
+        [string]$moduleList,
+        [string]$functionsToExport,
+        [string]$aliasesToExport,
+        [string]$variablesToExport,
+        [string]$cmdletsToExport,
+        [string]$dscResourcesToExport,
+        [string]$compatiblePSEditions,
+        [string]$defaultCommandPrefix
+    )
+
+    process {
+        # Create a new XML File with config root node
+        $oXMLRoot = New-Object System.XML.XMLDocument
+
+        # New Node
+        $oXMLContent = $oXMLRoot.CreateElement('newModuleManifest')
+
+        $MyParams = $PSCmdlet.MyInvocation.BoundParameters
+        $MyParams.Keys | ForEach-Object {
+            Write-Verbose "..Adding parameter $($_)"
+            $ParamName = $_
+            $ParamType = $MyParams[$_].GetType().Name
+            $ParamValue = $MyParams[$_]
+            switch ($ParamType) {
+                'SwitchParameter' {
+                    $oXMLContent.SetAttribute($ParamName, 'true')
+                }
+                default {
+                    $oXMLContent.SetAttribute($ParamName, $ParamValue)
+                }
+            }
+        }
+
+        # Append as child to an existing node
+        $null = $oXMLRoot.appendChild($oXMLContent)
+
+        # Return the result
+        $oXMLRoot.InnerXML
+    }
+}
+
+<#
+.SYNOPSIS
+A simple helper function to create a plaster modify xml block
+.DESCRIPTION
+A simple helper function to create a plaster modify xml block.
+.PARAMETER Path
+Specifies the relative path, under the destination folder, of the file to be modified
+.PARAMETER Encoding
+File encoding for the output
+.PARAMETER Original
+The original text, or regular expression match to replace
+.PARAMETER OriginalExpand
+Whether to expand variables within the original for match.
+.PARAMETER Substitute
+The replacement text to substitute in place of the original text
+.PARAMETER SubstituteExpand
+Whether to expand variables within the substitute text
+.PARAMETER Condition
+Used to determine whether this directive is executed
+.PARAMETER OpenInEditor
+Specifies whether the file should be opened in the editor (true) after scaffolding or not (false)
+.EXAMPLE
+Write-PlasterManifestContentModify -Path '.vscode\tasks.json' -Encoding 'UTF8' -Condition '$PLASTER_PARAM_Editor -eq "VSCode"' -ReplaceCondition "`$PLASTER_FileContent -notmatch '// Author:'" -Original '(?s)^(.*)' -Substitute '// Author: $PLASTER_PARAM_FullName`r`n`$1' -SubstituteExpand $true
+.NOTES
+This only outputs a an xml string that needs to be combined as part of a larger content block to create your manifest file.
+.LINK
+https://github.com/PowerShell/Plaster/blob/master/docs/en-US/about_Plaster_CreatingAManifest.help.md
+#>
+function Write-PlasterManifestContentModify {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$Original,
+        [bool]$OriginalExpand,
+        [string]$Substitute,
+        [bool]$SubstituteExpand,
+        [string]$Condition,
+        [string]$ReplaceCondition,
+        [bool]$openInEditor,
+        [string]$Encoding
+    )
+
+    process {
+        # Create a new XML File with config root node
+        $oXMLRoot = New-Object System.XML.XMLDocument
+
+        # New Node
+        $oXMLContent = $oXMLRoot.CreateElement('Modify')
+
+        $oXMLContent.SetAttribute("path", $Path)
+        if (-not [string]::IsNullOrEmpty($Condition)) {
+            $oXMLContent.SetAttribute("condition", $Condition)
+        }
+        if (-not [string]::IsNullOrEmpty($Encoding)) {
+            $oXMLContent.SetAttribute("encoding", $Encoding)
+        }
+        if ($openInEditor) {
+            $oXMLContent.SetAttribute("openInEditor", 'true')
+        }
+
+        $null = $oXMLRoot.appendChild($oXMLContent)
+
+        $oXMLReplace = $oXMLRoot.CreateElement("replace")
+        if (-not [string]::IsNullOrEmpty($ReplaceCondition)) {
+            $oXMLReplace.SetAttribute("condition", $ReplaceCondition)
+        }
+        $null = $oXMLRoot.Modify.appendChild($oXMLReplace)
+
+        if (-not [string]::IsNullOrEmpty($Original)) {
+            $oXMLReplaceOriginal = $oXMLRoot.CreateElement("original")
+            $oXMLReplaceOriginal.InnerText = $Original
+            if ($OriginalExpand) {
+                $oXMLReplaceOriginal.SetAttribute("expand", 'true')
+            }
+            $null = $oXMLRoot.modify['replace'].appendChild($oXMLReplaceOriginal)
+        }
+        if (-not [string]::IsNullOrEmpty($Substitute)) {
+            $oXMLReplaceSub = $oXMLRoot.CreateElement("substitute")
+            $oXMLReplaceSub.InnerText = $Substitute
+            if ($SubstituteExpand) {
+                $oXMLReplaceSub.SetAttribute("expand", 'true')
+            }
+            $null = $oXMLRoot.modify['replace'].appendChild($oXMLReplaceSub)
+        }
+
+        # Append as child to an existing node
+        $null = $oXMLRoot.appendChild($oXMLContent)
+
+        # Return the result
+        $oXMLRoot.InnerXML
+    }
+}
+
+<#
+.SYNOPSIS
+A simple helper function to create a plaster requireModule xml block
+.DESCRIPTION
+A simple helper function to create a plaster requireModule xml block.
+.PARAMETER Name
+Name of required module
+.PARAMETER Condition
+Condition to be met to process this content block
+.PARAMETER MinimumVersion
+Minimum version for module requirement
+.PARAMETER MaximumVersion
+Maximum version for module requirement
+.PARAMETER RequiredVersion
+Required module version.
+.PARAMETER Message
+Message to display if the module requirements are not met for requireModule. For message this is just the message to display.
+.EXAMPLE
+Write-PlasterManifestContentRequireModule -Name 'Pester' -MinimumVersion '4.0.2' -Message 'Pester 4.0.2 is required for this plaster scaffold.'
+.NOTES
+This only outputs a an xml string that needs to be combined as part of a larger content block to create your manifest file.
+.LINK
+https://github.com/PowerShell/Plaster/blob/master/docs/en-US/about_Plaster_CreatingAManifest.help.md
+#>
+function Write-PlasterManifestContentRequireModule {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Position = 1)]
+        [string]$Condition,
+        [Parameter(Position = 2)]
+        [string]$MinimumVersion,
+        [Parameter(Position = 3)]
+        [string]$MaximumVersion,
+        [Parameter(Position = 4)]
+        [string]$RequiredVersion,
+        [Parameter(Position = 5)]
+        [string]$Message
+    )
+
+    process {
+        if ($RequiredVersion -and ($MinimumVersion -or $MaximumVersion)) {
+            throw 'Unable to use either MinimumVersion or MaximumVersion when defining RequiredVersion.'
+        }
+        # Create a new XML File with config root node
+        $oXMLRoot = New-Object System.XML.XMLDocument
+
+        # New Node
+        $oXMLContent = $oXMLRoot.CreateElement('requireModule')
+        if (-not [string]::IsNullOrEmpty($Condition)) {
+            $oXMLContent.SetAttribute("condition", $Condition)
+        }
+        if (-not [string]::IsNullOrEmpty($Name)) {
+            $oXMLContent.SetAttribute("name", $Name)
+        }
+        if (-not [string]::IsNullOrEmpty($MinimumVersion)) {
+            $oXMLContent.SetAttribute("minimumVersion", $MinimumVersion)
+        }
+        if (-not [string]::IsNullOrEmpty($MaximumVersion)) {
+            $oXMLContent.SetAttribute("maximumVersion", $MaximumVersion)
+        }
+        if (-not [string]::IsNullOrEmpty($RequiredVersion)) {
+            $oXMLContent.SetAttribute("requiredVersion", $RequiredVersion)
+        }
+        if (-not [string]::IsNullOrEmpty($Message)) {
+            $oXMLContent.SetAttribute("message", $Message)
+        }
+
+        # Append as child to an existing node
+        $null = $oXMLRoot.appendChild($oXMLContent)
+
+        # Return the result
+        $oXMLRoot.InnerXML
+    }
+}
+
+<#
+.SYNOPSIS
+A wraper function to create a plaster content xml block.
+
+.DESCRIPTION
+A simple helper function to create a plaster content xml block. This function
+is best used with an array of hashtables for rapid creation of a Plaster content
+block.
+.PARAMETER ContentType
+Type of content block to create
+.PARAMETER Path
+Specifies the relative path, under the destination folder, of the file to be modified
+.PARAMETER Source
+Source file
+.PARAMETER Destination
+Where the module manifest, templatefile, or template will be created
+.PARAMETER Condition
+Used to determine whether this directive is executed
+.PARAMETER OpenInEditor
+Specifies whether the file should be opened in the editor (true) after scaffolding or not (false)
+.PARAMETER Encoding
+Encoding for created file
+.PARAMETER author
+Module manifest author
+.PARAMETER companyName
+Module manifest company
+.PARAMETER description
+Module description
+.PARAMETER moduleVersion
+Module version
+.PARAMETER rootModule
+Root module for th emanifest
+.PARAMETER copyright
+Module manifest copyright
+.PARAMETER tags
+Module tags
+.PARAMETER projectUri
+Module project website
+.PARAMETER licenseUri
+Module license website
+.PARAMETER iconUri
+Module icon link
+.PARAMETER helpInfoUri
+Module help website
+.PARAMETER nestedModules
+Nested modules
+.PARAMETER requiredModules
+Required modules for the module manifest
+.PARAMETER typesToProcess
+Types to process for this module
+.PARAMETER formatsToProcess
+Formats to process for this module
+.PARAMETER scriptsToProcess
+Scripts to process for this module
+.PARAMETER requiredAssemblies
+Required assemblies for this module
+.PARAMETER fileList
+List of files for this module
+.PARAMETER moduleList
+List of modules for thid module
+.PARAMETER functionsToExport
+Functions to export for this module
+.PARAMETER aliasesToExport
+Aliases to export for th is module
+.PARAMETER variablesToExport
+Variables to export for this module
+.PARAMETER cmdletsToExport
+Cmdlets to export for this module
+.PARAMETER dscResourcesToExport
+DSC resources to export for this module
+.PARAMETER compatiblePSEditions
+Compatible versions of PowerShell for this module
+.PARAMETER defaultCommandPrefix
+Default prefix for commands exported from this module
+.PARAMETER MinimumVersion
+Minimum version for module requirement
+.PARAMETER MaximumVersion
+Maximum version for module requirement
+.PARAMETER RequiredVersion
+Required module version.
+.PARAMETER Message
+Message to display if the module requirements are not met for requireModule. For message this is just the message to display.
+.PARAMETER NoNewLine
+The message will not include a newline at the end
+.PARAMETER Original
+The original text, or regular expression match to replace
+.PARAMETER OriginalExpand
+Whether to expand variables within the original for match.
+.PARAMETER Substitute
+The replacement text to substitute in place of the original text
+.PARAMETER SubstituteExpand
+Whether to expand variables within the substitute text
+.EXAMPLE
+$MyPlasterContent = @(
+    @{
+        'ContentType' = 'Message'
+        'Message' = 'Building out your module and preparing the environment...'
+        'NoNewLine' = $true
+    },
+    @{
+        'ContentType' = 'newModuleManifest'
+        'Destination' = '${PLASTER_PARAM_ModuleName}.psd1'
+        'moduleVersion' = '${PLASTER_PARAM_ModuleVersion}'
+        'rootModule' = '${PLASTER_PARAM_ModuleName}.psm1'
+        'copyright' = '(c) 2017 ${PLASTER_PARAM_ModuleAuthor}. All rights reserved.'
+        'projectURI' = '${PLASTER_PARAM_ModuleWebsite}'
+        'licenseURI' = '${PLASTER_PARAM_ModuleWebsite}/raw/master/license.md'
+        'iconURI' = '${PLASTER_PARAM_ModuleWebsite}/raw/master/src/other/powershell-project.png'
+        'author' = '${PLASTER_PARAM_ModuleAuthor}'
+        'companyname' = '${PLASTER_PARAM_ModuleAuthor}'
+        'description' = '${PLASTER_PARAM_ModuleDescription}'
+        'tags' = '${PLASTER_PARAM_tags}'
+        'encoding' = 'UTF8-NoBOM'
+    },
+    @{
+        'ContentType' = 'file'
+        'Source' = 'scaffold\src\other\*'
+        'Destination' = 'src\${PLASTER_PARAM_OtherModuleSource}'
+    },
+    @{
+        'ContentType' = 'file'
+        'Source' = 'scaffold\src\private\*'
+        'Destination' = 'src\${PLASTER_PARAM_PrivateFunctionSource}'
+    },
+    @{
+        'ContentType' = 'file'
+        'Source' = 'scaffold\src\public\*'
+        'Destination' = 'src\${PLASTER_PARAM_PublicFunctionSource}'
+    },
+    @{
+        'ContentType' = 'templateFile'
+        'Source' = 'scaffold\ModuleName.psm1'
+        'Destination' = '${PLASTER_PARAM_ModuleName}.psm1'
+    },
+    @{
+        'ContentType' = 'Modify'
+        'Path' = '.vscode\tasks.json'
+        'Encoding' = 'UTF8'
+        'Condition' = '$PLASTER_PARAM_Editor -eq "VSCode"'
+        'ReplaceCondition' = "`$PLASTER_FileContent -notmatch '// Author:'"
+        'Original' = '(?s)^(.*)'
+        'Substitute' = '// Author: $PLASTER_PARAM_FullName`r`n`$1'
+        'SubstituteExpand' = $true
+    },
+    @{
+        'ContentType' = 'Message'
+        'Message' = '-= COMPLETE! =-'
+    }
+) | Write-PlasterManifestContent
+.NOTES
+Not all content types are sanitized for valid output yet so it is vital to test your resulting
+Plaster manifest file with Test-PlasterManifest -Verbose.
+.LINK
+https://github.com/PowerShell/Plaster/blob/master/docs/en-US/about_Plaster_CreatingAManifest.help.md
+#>
+function Write-PlasterManifestContent {
+[CmdletBinding()]
+    param (
+        [Parameter()]
+        [ValidateSet('File', 'TemplateFile', 'Message', 'Modify', 'newModuleManifest', 'requireModule')]
+        [Alias('Type')]
+        [string]$ContentType = 'Message',
+        [string]$Condition,
+        [string]$Source,
+        [string]$Destination,
+        [bool]$OpenInEditor,
+        [string]$Encoding,
+        [bool]$NoNewLine,
+        [string]$ReplaceCondition,
+        [string]$Original,
+        [bool]$OriginalExpand,
+        [string]$Substitute,
+        [bool]$SubstituteExpand,
+        [string]$Path,
+        [string]$author,
+        [string]$companyName,
+        [string]$description,
+        [string]$moduleVersion,
+        [string]$rootModule,
+        [string]$copyright,
+        [string]$tags,
+        [string]$projectUri,
+        [string]$licenseUri,
+        [string]$iconUri,
+        [string]$helpInfoUri,
+        [string]$nestedModules,
+        [string]$requiredModules,
+        [string]$typesToProcess,
+        [string]$formatsToProcess,
+        [string]$scriptsToProcess,
+        [string]$requiredAssemblies,
+        [string]$fileList,
+        [string]$moduleList,
+        [string]$functionsToExport,
+        [string]$aliasesToExport,
+        [string]$variablesToExport,
+        [string]$cmdletsToExport,
+        [string]$dscResourcesToExport,
+        [string]$compatiblePSEditions,
+        [string]$defaultCommandPrefix,
+        [string]$Name,
+        [string]$MinimumVersion,
+        [string]$MaximumVersion,
+        [string]$RequiredVersion,
+        [string]$Message,
+        [Parameter(ParameterSetName = "pipeline", ValueFromPipeLine = $true, Position = 0)]
+        [Hashtable]$Obj
+    )
+
+    process {
+        # If a hash is passed then recall this function with the hash splatted instead.
+        if ($null -ne $Obj) {
+            return Write-PlasterManifestContent @obj
+        }
+
+        # Update the element based on the type
+        switch ($ContentType) {
+            'File' {
+                Write-PlasterManifestContentFile -Source $Source -Destination $Destination -Condition $Condition -OpenInEditor $OpenInEditor
+            }
+            'TemplateFile' {
+                Write-PlasterManifestContentTemplateFile -Source $Source -Destination $Destination -Condition $Condition -OpenInEditor $OpenInEditor -Encoding $Encoding
+            }
+            'Message' {
+                Write-PlasterManifestContentMessage -Message $Message -Condition $Condition -NoNewLine $NoNewLine
+            }
+            'Modify' {
+                $MSplat = @{
+                    Path = $Path
+                    Condition = $Condition
+                    Encoding = $Encoding
+                    Original = $Original
+                    OriginalExpand = $OriginalExpand
+                    Substitute = $Substitute
+                    SubstituteExpand = $SubstituteExpand
+                    ReplaceCondition = $ReplaceCondition
+                }
+                Write-PlasterManifestContentModify @MSplat
+            }
+            'newModuleManifest' {
+                $NMMSplat = @{}
+                $ValidParams = @(
+                    'Destination',
+                    'Condition',
+                    'OpenInEditor',
+                    'Encoding',
+                    'author',
+                    'companyName',
+                    'description',
+                    'moduleVersion',
+                    'rootModule',
+                    'copyright',
+                    'tags',
+                    'projectUri',
+                    'licenseUri',
+                    'iconUri',
+                    'helpInfoUri',
+                    'nestedModules',
+                    'requiredModules',
+                    'typesToProcess',
+                    'formatsToProcess',
+                    'scriptsToProcess',
+                    'requiredAssemblies',
+                    'fileList',
+                    'moduleList',
+                    'functionsToExport',
+                    'aliasesToExport',
+                    'variablesToExport',
+                    'cmdletsToExport',
+                    'dscResourcesToExport',
+                    'compatiblePSEditions',
+                    'defaultCommandPrefix'
+                )
+
+                $MyParams = $PSCmdlet.MyInvocation.BoundParameters
+                $MyParams.Keys | Where-Object {$ValidParams -contains $_} | ForEach-Object {
+                    $NMMSplat[$_] = $MyParams[$_]
+                }
+                Write-PlasterManifestContentNewModuleManifest @NMMSplat
+            }
+            'requireModule' {
+                $RMSplat = @{
+                    Name = $Name
+                    Condition = $Condition
+                    MinimumVersion = $MinimumVersion
+                    MaximumVersion = $MaximumVersion
+                    RequiredVersion = $RequiredVersion
+                    Message = $Message
+                }
+                Write-PlasterManifestContentRequireModule @RMSplat
+            }
+        }
+    }
+}

--- a/src/WritePlasterParameter.ps1
+++ b/src/WritePlasterParameter.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+A simple helper function to create a parameter xml block for plaster
+.DESCRIPTION
+A simple helper function to create a parameter xml block for plaster.  This function
+is best used with an array of hashtables for rapid creation of a Plaster parameter
+block.
+.PARAMETER Name
+The plaster element name
+.PARAMETER Type
+The type of plater parameter. Can be either text, choice, multichoice, user-fullname, or user-email
+.PARAMETER Prompt
+The prompt to be displayed
+.PARAMETER Default
+The default setting for this parameter
+.PARAMETER Store
+Specifies the store type of the value. Can be text or encrypted. If not defined then the default is text.
+.PARAMETER Choices
+An array of hashtables with each hash being a choice containing the lable, help, and value for the choice.
+.PARAMETER Obj
+Hashtable object containing all the parameters required for this function.
+.EXAMPLE
+$choice1 = @{
+    label = '&yes'
+    help = 'Process this'
+    value = 'true'
+}
+$choice2 = @{
+    label = '&no'
+    help = 'Do NOT Process this'
+    value = 'false'
+}
+
+Write-PlasterParameter -Name 'Editor' -type 'choice' -Prompt 'Choose your editor' -Default '0' -Store 'text' -Choices @($choice1,$choice2)
+.EXAMPLE
+$MyParams = @(
+@{
+    'Name' = "NugetAPIKey"
+    'Type' = "text"
+    'Prompt' = "Enter a PowerShell Gallery (aka Nuget) API key. Without this you will not be able to upload your module to the Gallery"
+    'Default' = ' '
+},
+@{
+    'Name' = "OptionAnalyzeCode"
+    'Type' = "choice"
+    'Prompt' = "Use PSScriptAnalyzer in the module build process (Recommended for Gallery uploading)?"
+    'Default' = "0"
+    'Store' = "text"
+    'Choices' = @(
+        @{
+            Label = "&Yes"
+            Help = "Enable script analysis"
+            Value = "True"
+        },
+        @{
+            Label = "&No"
+            Help = "Disable script analysis"
+            Value = "False"
+        }
+    )
+}) | Write-PlasterParameter
+#>
+function Write-PlasterParameter {
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param (
+        [Parameter(ParameterSetName = "default", Mandatory = $true, Position = 0)]
+        [Alias('Name')]
+        [string]$ParameterName,
+
+        [Parameter(ParameterSetName = "default", Position = 1)]
+        [ValidateSet('text', 'choice', 'multichoice', 'user-fullname', 'user-email')]
+        [Alias('Type')]
+        [string]$ParameterType = 'text',
+
+        [Parameter(ParameterSetName = "default", Mandatory = $true, Position = 2)]
+        [Alias('Prompt')]
+        [ValidateNotNullOrEmpty()]
+        [string]$ParameterPrompt,
+
+        [Parameter(ParameterSetName = "default", Position = 3)]
+        [Alias('Default')]
+        [string]$ParameterDefault,
+
+        [Parameter(ParameterSetName = "default", Position = 4)]
+        [ValidateSet('text', 'encrypted')]
+        [AllowNull()]
+        [string]$Store,
+
+        [Parameter(ParameterSetName = "default", Position = 5)]
+        [Hashtable[]]$Choices,
+
+        [Parameter(ParameterSetName = "pipeline", ValueFromPipeLine = $true, Position = 0)]
+        [Hashtable]$Obj
+    )
+
+    process {
+        # If a hash is passed then recall this function with the hash splatted instead.
+        if ($null -ne $Obj) {
+            return Write-PlasterParameter @Obj
+        }
+
+        # Create a new XML File with config root node
+        $oXMLRoot = New-Object System.XML.XMLDocument
+
+        if (($Type -eq 'choice') -and ($Choices.Count -le 1)) {
+            throw 'You cannot setup a parameter of type "choice" without supplying an array of applicable choices to select from...'
+        }
+
+        # New Node
+        $oXMLParameter = $oXMLRoot.CreateElement("parameter")
+
+        # Append as child to an existing node
+        $Null = $oXMLRoot.appendChild($oXMLParameter)
+
+        # Add a Attributes
+        $oXMLParameter.SetAttribute("name", $ParameterName)
+        $oXMLParameter.SetAttribute("type", $ParameterType)
+        $oXMLParameter.SetAttribute("prompt", $ParameterPrompt)
+        if (-not [string]::IsNullOrEmpty($ParameterDefault)) {
+            $oXMLParameter.SetAttribute("default", $ParameterDefault)
+        }
+        if (-not [string]::IsNullOrEmpty($Store)) {
+            $oXMLParameter.SetAttribute("store", $Store)
+        }
+        if ($ParameterType -match 'choice|multichoice') {
+            if ($Choices.count -lt 1) {
+                Write-Warning 'The parameter type was choice/multichoice but there are less than 2 choices. Returning nothing.'
+                return
+            }
+            foreach ($Choice in $Choices) {
+                [System.XML.XMLElement]$oXMLChoice = $oXMLRoot.CreateElement("choice")
+                $oXMLChoice.SetAttribute("label", $Choice['Label'])
+                $oXMLChoice.SetAttribute("help", $Choice['help'])
+                $oXMLChoice.SetAttribute("value", $Choice['value'])
+                $null = $oXMLRoot['parameter'].appendChild($oXMLChoice)
+            }
+        }
+
+        $oXMLRoot.InnerXML
+    }
+}

--- a/test/WritePlasterContent.Tests.ps1
+++ b/test/WritePlasterContent.Tests.ps1
@@ -1,0 +1,60 @@
+. $PSScriptRoot\Shared.ps1
+
+$ExpectedResults = @{
+    Message = @'
+<message condition="$PLASTER_PARAM_Options -contains 'Pester'" noNewLine="true">
+
+A message to the user
+
+and other interesting information.</message>
+'@
+    Modify = @'
+<Modify path=".vscode\tasks.json" condition="$PLASTER_PARAM_Editor -eq 'VSCode'" encoding="UTF8"><replace condition="$PLASTER_FileContent -notmatch '// Author:'"><original>(?s)^(.*)</original><substitute expand="true">// Author: $PLASTER_PARAM_FullName`r`n`$1</substitute></replace></Modify>
+'@
+    TemplateFile = @'
+<templateFile source="test\Shared.ps1" destination="test\Shared.ps1" condition="$PLASTER_PARAM_Options -contains 'Pester'" />
+'@
+    File = @'
+<file source="Tests\*.tests.ps1" destination="test\" condition="$PLASTER_PARAM_Options -contains 'Pester'" />
+'@
+    newModuleManifest = @'
+<newModuleManifest copyright="Copyright 2017 (c) - $PLASTER_PARAM_FullName" description="$PLASTER_PARAM_ModuleDesc" destination="src\${PLASTER_PARAM_ModuleName}.psd1" tags="$PLASTER_PARAM_ModuleTags" author="$PLASTER_PARAM_FullName" rootModule="${PLASTER_PARAM_ModuleName}.psm1" companyName="$PLASTER_PARAM_FullName" projectUri="$PLASTER_PARAM_ModuleWebsite" encoding="UTF8-NoBOM" moduleVersion="$PLASTER_PARAM_Version" />
+'@
+    requireModule = @'
+<requireModule condition="$PLASTER_PARAM_Options -contains 'Pester'" name="Pester" minimumVersion="3.4.0" message="Without Pester, you will not be able to run the provided Pester test to validate your module manifest file.`nWithout version 3.4.0, VS Code will not display Pester warnings and errors in the Problems panel." />
+'@
+}
+
+
+Describe 'Write-PlasterManifestContent Command Tests' {
+    Context 'Message content' {
+        It 'Generates a valid message content XML block.' {
+          Write-PlasterManifestContent -ContentType 'Message' -Message "`n`nA message to the user`n`nand other interesting information." -Condition "`$PLASTER_PARAM_Options -contains `'Pester`'" -NoNewLine $true | Should BeExactly $ExpectedResults['Message']
+        }
+    }
+    Context 'Modify content' {
+        It 'Generates a valid modify content XML block.' {
+          Write-PlasterManifestContent -ContentType 'Modify' -Path '.vscode\tasks.json' -Encoding 'UTF8' -Condition "`$PLASTER_PARAM_Editor -eq 'VSCode'" -ReplaceCondition "`$PLASTER_FileContent -notmatch '// Author:'" -Original '(?s)^(.*)' -Substitute "// Author: `$PLASTER_PARAM_FullName``r``n```$1" -SubstituteExpand $true | Should BeExactly $ExpectedResults['Modify']
+        }
+    }
+    Context 'TemplateFile content' {
+        It 'Generates a valid TemplateFile content XML block.' {
+          Write-PlasterManifestContent -ContentType 'TemplateFile' -Source "test\Shared.ps1" -Destination "test\Shared.ps1" -Condition "`$PLASTER_PARAM_Options -contains 'Pester'" | Should BeExactly $ExpectedResults['TemplateFile']
+        }
+    }
+    Context 'File content' {
+        It 'Generates a valid File content XML block.' {
+          Write-PlasterManifestContent -ContentType 'File' -Source 'Tests\*.tests.ps1' -Destination 'test\' -Condition "`$PLASTER_PARAM_Options -contains 'Pester'" | Should BeExactly $ExpectedResults['File']
+        }
+    }
+    Context 'newModuleManifest content' {
+        It 'Generates a valid newModuleManifest content XML block.' {
+          Write-PlasterManifestContent -ContentType 'newModuleManifest' -Destination 'src\${PLASTER_PARAM_ModuleName}.psd1' -moduleVersion '$PLASTER_PARAM_Version' -rootModule '${PLASTER_PARAM_ModuleName}.psm1' -author '$PLASTER_PARAM_FullName' -description '$PLASTER_PARAM_ModuleDesc' -Encoding 'UTF8-NoBOM' -tags '$PLASTER_PARAM_ModuleTags' -projectUri '$PLASTER_PARAM_ModuleWebsite' -copyright 'Copyright 2017 (c) - $PLASTER_PARAM_FullName' -companyName '$PLASTER_PARAM_FullName' | Should BeExactly $ExpectedResults['newModuleManifest']
+        }
+    }
+    Context 'requireModule content' {
+        It 'Generates a valid requireModule content XML block.' {
+          Write-PlasterManifestContent -ContentType 'requireModule' -Name 'Pester' -Condition "`$PLASTER_PARAM_Options -contains 'Pester'" -MinimumVersion '3.4.0' -Message 'Without Pester, you will not be able to run the provided Pester test to validate your module manifest file.`nWithout version 3.4.0, VS Code will not display Pester warnings and errors in the Problems panel.' | Should BeExactly $ExpectedResults['requireModule']
+        }
+    }
+}

--- a/test/WritePlasterParameter.Tests.ps1
+++ b/test/WritePlasterParameter.Tests.ps1
@@ -1,0 +1,88 @@
+. $PSScriptRoot\Shared.ps1
+
+$ParamTypeMultiChoiceResult = @'
+<parameter name="Options" type="multichoice" prompt="Select desired options" default="0,1,2" store="text"><choice label="&amp;Pester test support" help="Adds Tests directory and a starter Pester Tests file." value="Pester" /><choice label="P&amp;Sake build script" help="Adds a PSake build script that generates the module directory for publishing to the PSGallery." value="PSake" /><choice label="&amp;Git" help="Adds a .gitignore file." value="Git" /><choice label="&amp;None" help="No options specified." value="None" /></parameter>
+'@
+
+$ParamTypeChoiceResult = @'
+<parameter name="License" type="choice" prompt="Select a license for your module" default="2" store="text"><choice label="&amp;Apache" help="Adds an Apache license file." value="Apache" /><choice label="&amp;MIT" help="Adds an MIT license file." value="MIT" /><choice label="&amp;None" help="No license specified." value="None" /></parameter>
+'@
+
+$ParamTypeTextResult = @'
+<parameter name="Version" type="text" prompt="Enter the version number for the module" default="0.0.1" />
+'@
+
+$ParamTypeUserFullNameResult = @'
+<parameter name="FullName" type="user-fullname" prompt="Enter your full name" store="text" />
+'@
+
+$ParamTypeUserEmailResult = @'
+<parameter name="UserEmail" type="user-email" prompt="Enter your email address" store="text" />
+'@
+
+Describe 'Write-PlasterParameter Command Tests' {
+    Context 'ParameterType of choice' {
+        It 'Generates valid parameter XML.' {
+          $Choices = @(
+            @{
+              label = '&Apache'
+              help = 'Adds an Apache license file.'
+              value = 'Apache'
+            },
+            @{
+              label='&MIT'
+              help="Adds an MIT license file."
+              value="MIT"
+            },
+            @{
+              label='&None'
+              help="No license specified."
+              value="None"
+            }
+          )
+          Write-PlasterParameter -ParameterType 'choice' -ParameterName 'License' -ParameterDefault '2' -Store 'text' -ParameterPrompt 'Select a license for your module' -Choices $Choices | Should Be $ParamTypeChoiceResult
+        }
+    }
+    Context 'ParameterType of multichoice' {
+        It 'Generates valid parameter XML.' {
+          $Choices = @(
+            @{
+              label='&Pester test support'
+              help="Adds Tests directory and a starter Pester Tests file."
+              value="Pester"
+            },
+            @{
+              label='P&Sake build script'
+              help="Adds a PSake build script that generates the module directory for publishing to the PSGallery."
+              value="PSake"
+            },
+            @{
+              label='&Git'
+              help="Adds a .gitignore file."
+              value="Git"
+            },
+            @{
+              label='&None'
+              help="No options specified."
+              value="None"
+            }
+          )
+          Write-PlasterParameter -ParameterType 'multichoice' -ParameterName 'Options' -ParameterDefault '0,1,2' -Store 'text' -ParameterPrompt 'Select desired options' -Choices $Choices | Should Be $ParamTypeMultiChoiceResult
+        }
+    }
+    Context 'ParameterType of text' {
+        It 'Generates valid parameter XML.' {
+          Write-PlasterParameter -ParameterType 'text' -ParameterName 'Version' -ParameterPrompt 'Enter the version number for the module' -ParameterDefault '0.0.1' | Should BeExactly $ParamTypeTextResult
+        }
+    }
+    Context 'ParameterType of user-fullname' {
+        It 'Generates valid parameter XML.' {
+          Write-PlasterParameter -ParameterType 'user-fullname' -ParameterName 'FullName' -ParameterPrompt 'Enter your full name' -Store 'text' | Should BeExactly $ParamTypeUserFullNameResult
+        }
+    }
+    Context 'ParameterType of user-email' {
+        It 'Generates valid parameter XML.' {
+          Write-PlasterParameter -ParameterType 'user-email' -ParameterName 'UserEmail' -ParameterPrompt 'Enter your email address' -Store 'text' | Should BeExactly $ParamTypeUserEmailResult
+        }
+    }
+}


### PR DESCRIPTION
- Added some minor updates to the xsd schema to include more parameters for new-modulemanifest.
- Added code to invoke-plaster to accommodate the change above (and automatically look for more module manifest settings to pull in for existing manifest files.
- Added 2 helper functions to more easily create both parameter and content xml code snippets for plaster manifest files from standard PowerShell hashes (Write-PlasterContent and Write-PlasterParameter).