### PR TITLE
Remove isShellCommand=true from tasks.json.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,28 +9,24 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-	"version": "0.1.0",
+	"version": "2.0.0",
 
-	// Start PowerShell
+    // Start PowerShell
     "windows": {
-        "command": "${env.windir}\\sysnative\\windowspowershell\\v1.0\\PowerShell.exe"
+        "command": "${env.windir}\\sysnative\\windowspowershell\\v1.0\\PowerShell.exe",
+        "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
     },
     "linux": {
-        "command": "/usr/bin/powershell"
+        "command": "/usr/bin/powershell",
+        "args": [ "-NoProfile" ]
     },
     "osx": {
-        "command": "/usr/local/bin/powershell"
+        "command": "/usr/local/bin/powershell",
+        "args": [ "-NoProfile" ]
     },
-
-	// The command is a shell script
-	"isShellCommand": true,
 
 	// Show the output window always
 	"showOutput": "always",
-
-    "args": [
-        "-NoProfile", "-ExecutionPolicy", "Bypass"
-    ],
 
     // Associate with test task runner
     "tasks": [

--- a/src/Templates/NewPowerShellScriptModule/editor/VSCode/tasks.json
+++ b/src/Templates/NewPowerShellScriptModule/editor/VSCode/tasks.json
@@ -9,28 +9,24 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-	"version": "0.1.0",
+	"version": "2.0.0",
 
-	// Start PowerShell
+    // Start PowerShell
     "windows": {
-        "command": "${env.windir}\\sysnative\\windowspowershell\\v1.0\\PowerShell.exe"
+        "command": "${env.windir}\\sysnative\\windowspowershell\\v1.0\\PowerShell.exe",
+        "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
     },
     "linux": {
-        "command": "/usr/bin/powershell"
+        "command": "/usr/bin/powershell",
+        "args": [ "-NoProfile" ]
     },
     "osx": {
-        "command": "/usr/local/bin/powershell"
+        "command": "/usr/local/bin/powershell",
+        "args": [ "-NoProfile" ]
     },
-
-	// The command is a shell script
-	"isShellCommand": true,
 
 	// Show the output window always
 	"showOutput": "always",
-
-    "args": [
-        "-NoProfile", "-ExecutionPolicy", "Bypass"
-    ],
 
     // Associate with test task runner
     "tasks": [


### PR DESCRIPTION
This command isn't needed when you tell VSCode which exe to execute (where isShellCommand tells VSCode to use the user's default shell).