### PR TITLE
Fix Plaster on latest version Powershell for unix

### DIFF
--- a/src/TestPlasterManifest.ps1
+++ b/src/TestPlasterManifest.ps1
@@ -14,7 +14,7 @@ function Test-PlasterManifest {
     )
 
     begin {
-        $schemaPath = [io.path]::combine($PSScriptRoot, "Schema", "PlasterManifest-v1.xsd")
+        $schemaPath = [System.IO.Path]::Combine($PSScriptRoot, "Schema", "PlasterManifest-v1.xsd")
 
         # Schema validation is not available on .NET Core - at the moment.
         if ('System.Xml.Schema.XmlSchemaSet' -as [type]) {

--- a/src/TestPlasterManifest.ps1
+++ b/src/TestPlasterManifest.ps1
@@ -14,7 +14,7 @@ function Test-PlasterManifest {
     )
 
     begin {
-        $schemaPath = "$PSScriptRoot\Schema\PlasterManifest-v1.xsd"
+        $schemaPath = [io.path]::combine($PSScriptRoot, "Schema", "PlasterManifest-v1.xsd")
 
         # Schema validation is not available on .NET Core - at the moment.
         if ('System.Xml.Schema.XmlSchemaSet' -as [type]) {


### PR DESCRIPTION
As of a recent Powershell 6 beta release (I'm using beta-5), calling `Invoke-Plaster` on a non-windows host would give this error message;

```
Plaster\Test-PlasterManifest : Exception calling "Add" with "2" argument(s): "Could not find file
'/Users/edmundd/.local/share/powershell/Modules/Plaster/1.0.1\Schema\PlasterManifest-v1.xsd'."
At /Users/edmundd/.local/share/powershell/Modules/Plaster/1.0.1/InvokePlaster.ps1:179 char:29
+ ... $manifest = Plaster\Test-PlasterManifest -Path $manifestPath -ErrorAc ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Test-PlasterManifest], MethodInvocationException
    + FullyQualifiedErrorId : FileNotFoundException,Test-PlasterManifest
```

This problem has only become apparent due to a  recent change in dotnet core seems to have made `System.Xml.Schema.XmlSchemaSet` a valid type, whereas before this bit of code was skipped in Unix powershell.

The issue was that Unix Powershell doesn't like mixed path separators in a single path, so threw an exception when it couldn't find that file. The fix is to use `[io.path]::combine` so that dotnet can work out the correct path separator to use.
