### PR TITLE
Included CmdletsToExport and AliasesToExport

### DIFF
--- a/src/Plaster.psd1
+++ b/src/Plaster.psd1
@@ -55,6 +55,12 @@
         'Get-PlasterTemplate',
         'Test-PlasterManifest'
         )
+    
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport = @()
+
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport = @()
 
     # HelpInfo URI of this module
     # HelpInfoURI = ''


### PR DESCRIPTION
The PSD1 file for the module doesn't include CmdletsToExport and AliasesToExport, best perfroamcne states to include these as empty arrays.