### PR TITLE
Adding the Compare-Object command to constrained Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - The parameter element now supports a condition attribute so that prompting for parameters can be
   conditional based on environmental factors (such as OS) or answers to previous parameter prompts.
   This allows template authors to build a "dynamic" set of prompts.
+- Added constrained runspace cmdlet: Compare-Object [#287](https://github.com/PowerShell/Plaster/issues/236).
 ### Changed
 - Simplified New Module Script template user choices i.e. removed prompt for adding Pester test.
   The test is now always added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - The parameter element now supports a condition attribute so that prompting for parameters can be
   conditional based on environmental factors (such as OS) or answers to previous parameter prompts.
   This allows template authors to build a "dynamic" set of prompts.
-- Added constrained runspace cmdlet: Compare-Object [#287](https://github.com/PowerShell/Plaster/issues/236).
+- Added constrained runspace cmdlet: Compare-Object [#286](https://github.com/PowerShell/Plaster/issues/287).
 ### Changed
 - Simplified New Module Script template user choices i.e. removed prompt for adding Pester test.
   The test is now always added.

--- a/docs/en-US/about_Plaster_CreatingAManifest.help.md
+++ b/docs/en-US/about_Plaster_CreatingAManifest.help.md
@@ -431,6 +431,7 @@ In addition, the following commands are available:
 - Get-Module
 - Get-Variable
 - Test-Path
+- Compare-Object
 
 # EXAMPLES
 You can create a base Plaster manifest by running the New-PlasterManifest command.

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -267,6 +267,9 @@ function Invoke-Plaster {
             $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Out-String',([Microsoft.PowerShell.Commands.OutStringCommand]),$null
             $iss.Commands.Add($ssce)
 
+            $ssce = New-Object System.Management.Automation.Runspaces.SessionStateCmdletEntry 'Compare-Object',([Microsoft.PowerShell.Commands.CompareObjectCommand]),$null
+            $iss.Commands.Add($ssce)
+
             $scopedItemOptions = [System.Management.Automation.ScopedItemOptions]::AllScope
             $plasterVars = Get-Variable -Name PLASTER_*,PSVersionTable
             if (Test-Path Variable:\IsLinux) {

--- a/test/ConditionEval.Tests.ps1
+++ b/test/ConditionEval.Tests.ps1
@@ -112,5 +112,32 @@ Describe 'Condition Attribute Evaluation Tests' {
             # condition should return true which will copy over the file foo.txt
             Get-Item $OutDir\foo.txt -ErrorAction SilentlyContinue | Foreach-Object Name | Should BeExactly foo.txt
         }
+
+        It 'Compare-Object command is available' {
+            CleanDir $TemplateDir
+            CleanDir $OutDir
+
+            @"
+<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="0.3" xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+    <metadata>
+        <name>TemplateName</name>
+        <id>513d2fdc-3cce-47d9-9531-d85114efb224</id>
+        <version>0.2.0</version>
+        <title>Testing</title>
+        <description>Manifest file for testing.</description>
+        <tags></tags>
+    </metadata>
+    <content>
+        <file source='Recurse\foo.txt' destination='foo.txt' condition='Compare-Object -IncludeEqual -ExcludeDifferent @("a","b") @("b","c")'/>
+    </content>
+</plasterManifest>
+"@ | Out-File $PlasterManifestPath -Encoding utf8
+
+            Copy-Item $PSScriptRoot\Recurse $TemplateDir -Recurse
+            Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6> $null
+            # condition should return true which will copy over the file foo.txt
+            Get-Item $OutDir\foo.txt -ErrorAction SilentlyContinue | Foreach-Object Name | Should BeExactly foo.txt
+        }
     }
 }


### PR DESCRIPTION
An attempt to fix PowerShell/Plaster#286

Added the command Compare-Object to the constrained endpoint.