### PR TITLE
added copyright to the schema

### DIFF
--- a/src/Schema/PlasterManifest-v1.xsd
+++ b/src/Schema/PlasterManifest-v1.xsd
@@ -438,6 +438,11 @@
                       <xs:documentation>Specifies the value of the CompanyName property.</xs:documentation>
                     </xs:annotation>
                   </xs:attribute>
+                  <xs:attribute name="copyright" type="xs:string">
+                    <xs:annotation>
+                      <xs:documentation>Specifies a copyright statement for the module.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
                   <xs:attribute name="description" type="xs:string">
                     <xs:annotation>
                       <xs:documentation>Specifies the value of the Description property. Note: this field is required for module submissions to the PowerShell Gallery.</xs:documentation>


### PR DESCRIPTION
The copyright is missing from the schema, but I wanted to generate an internal company module template with our default copyright, so I've added it.

Let me know if I am missing something and should have done it differently.

Thanks
