### PR TITLE
Updated vscode template

### DIFF
--- a/src/Templates/NewPowerShellScriptModule/editor/VSCode/tasks.json
+++ b/src/Templates/NewPowerShellScriptModule/editor/VSCode/tasks.json
@@ -1,42 +1,16 @@
-// Available variables which can be used inside of strings.
-// ${workspaceRoot}: the root folder of the team
-// ${file}: the current opened file
-// ${relativeFile}: the current opened file relative to workspaceRoot
-// ${fileBasename}: the current opened file's basename
-// ${fileDirname}: the current opened file's dirname
-// ${fileExtname}: the current opened file's extension
-// ${cwd}: the current working directory of the spawned process
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-	"version": "2.0.0",
-
-    // Start PowerShell
-    "windows": {
-        "command": "${env:windir}/System32/WindowsPowerShell/v1.0/powershell.exe",
-        //"command": "${env:ProgramFiles}/PowerShell/6.0.0/powershell.exe",
-        "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
-    },
-    "linux": {
-        "command": "/usr/bin/powershell",
-        "args": [ "-NoProfile" ]
-    },
-    "osx": {
-        "command": "/usr/local/bin/powershell",
-        "args": [ "-NoProfile" ]
-    },
-
-    // Associate with test task runner
+    "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "Test",
-            "suppressTaskName": true,
-            "isTestCommand": true,
-            "args": [
-                "Write-Host 'Invoking Pester...'; $ProgressPreference = 'SilentlyContinue'; Invoke-Pester -Script test -PesterOption @{IncludeVSCodeMarker=$true};",
-                "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
-            ],
-            "problemMatcher": "$pester"
+            "label": "Run tests",
+            "type": "shell",
+            "group": "test",
+            "command": "Invoke-Pester -Script test -PesterOption @{IncludeVSCodeMarker=$true}",
+            "problemMatcher": [
+                "$pester"
+            ]
         }
-	]
+    ]
 }


### PR DESCRIPTION
Hello,

in VSCode 1.21 the test task fails with:

> Ausnahme beim Aufrufen von "GetSteppablePipeline" mit 1 Argument(en):  "Der Ausdruck nach "&" in einem Pipelineelement hat ein ungültiges Objekt erzeugt. Der Ausdruck muss einen Befehlsnamen, Skriptblock oder ein
CommandInfo-Objekt ergeben."

Further there were some warnings in the tasks.json, since VSCode changed the tasks to version 1.14.

I fixed it for the latest version of VSCode and testet it on a updated Windows 10, but not on Linux and MacOS.

Thanks,
Steffen