### PR TITLE
Set new powershell executable name to pwsh

### DIFF
--- a/examples/NewModule/editor/VSCode/tasks_psake_pester.json
+++ b/examples/NewModule/editor/VSCode/tasks_psake_pester.json
@@ -17,11 +17,11 @@
         "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
     },
     "linux": {
-        "command": "/usr/bin/powershell",
+        "command": "/usr/bin/pwsh",
         "args": [ "-NoProfile" ]
     },
     "osx": {
-        "command": "/usr/local/bin/powershell",
+        "command": "/usr/local/bin/pwsh",
         "args": [ "-NoProfile" ]
     },
 


### PR DESCRIPTION
The example fails on macOS because of the PowerShell executable name set to `powershell` instead of `pwsh`