### PR TITLE
Added name paramter to Get-PlasterTemplate to filter the results

### DIFF
--- a/docs/en-US/Get-PlasterTemplate.md
+++ b/docs/en-US/Get-PlasterTemplate.md
@@ -14,12 +14,12 @@ cmdlet.
 
 ### Path
 ```
-Get-PlasterTemplate [[-Path] <String>] [[-Name] <String>] [-Recurse] [<CommonParameters>]
+Get-PlasterTemplate [[-Path] <String>] [[-Name] <String>] [[-Tag] <String>] [-Recurse] [<CommonParameters>]
 ```
 
 ### IncludedTemplates
 ```
-Get-PlasterTemplate [-IncludeInstalledModules] [[-Name] <String>] [<CommonParameters>]
+Get-PlasterTemplate [-IncludeInstalledModules] [[-Name] <String>] [[-Tag] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -28,6 +28,7 @@ the set of templates that are shipped with Plaster.  Specifying no arguments wil
 cause only the built-in Plaster templates to be returned.  Using the -IncludeInstalledModules
 switch will also search the PSModulePath for PowerShell modules that advertise
 Plaster templates that they include. Using the -Name parameter limits the results based on name.
+Using the -Tag parameter limits the results based on the template tags.
 
 
 The objects returned from this cmdlet will provide details about each individual
@@ -87,6 +88,18 @@ PS C:\> Invoke-Plaster -TemplatePath $templates[0].TemplatePath -DestinationPath
 This will get a list of Plaster templates, both built-in and included with installed
 modules, where the name matches 'new*'.
 It will then use the first template found to create a new module at the specified path.
+
+### Example 6
+```
+PS C:\> $templates = Get-PlasterTemplate -IncludeInstalledModules -tag module*
+
+PS C:\> $templates[0].InvokePlaster()
+```
+
+This will get a list of Plaster templates, both built-in and included with installed
+modules, where the name matches 'module*'.
+It will then use the first template found to create a new module at the specified path
+using the InvokePlaster script method that is available on the returned object.
 ## PARAMETERS
 
 ### -IncludeInstalledModules
@@ -125,6 +138,21 @@ Indicates that this cmdlet gets the items in the specified locations and in all 
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: Path
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Limits the templates returned to those that match the template name. Wildcard characters are permitted.
+
+```yaml
+Type: String
 Parameter Sets: Path, IncludedTemplates
 Aliases:
 
@@ -135,17 +163,17 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Name
-Limits the templates returned to those that match the template name. Wildcard characters are permitted.
+### -Tag
+Limits the templates returned to those that match the template tags. Wildcard characters are permitted.
 
 ```yaml
 Type: String
-Parameter Sets: Path
+Parameter Sets: Path, IncludedTemplates
 Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: *
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -171,6 +199,10 @@ This output object provides the following properties:
 - Description: Text describing the template and what it creates
 - Tags: A list of tag strings which categorize the template
 - TemplatePath: The template's folder path in the filesystem
+
+This output object provides the following methods:
+
+- InvokePlaster(): Runs Invoke-Plaster against the template
 
 ## NOTES
 

--- a/docs/en-US/Get-PlasterTemplate.md
+++ b/docs/en-US/Get-PlasterTemplate.md
@@ -14,12 +14,12 @@ cmdlet.
 
 ### Path
 ```
-Get-PlasterTemplate [[-Path] <String>] [-Recurse] [<CommonParameters>]
+Get-PlasterTemplate [[-Path] <String>] [[-Name] <String>] [-Recurse] [<CommonParameters>]
 ```
 
 ### IncludedTemplates
 ```
-Get-PlasterTemplate [-IncludeInstalledModules] [<CommonParameters>]
+Get-PlasterTemplate [-IncludeInstalledModules] [[-Name] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,7 +27,7 @@ Retrieves a list of available Plaster templates from the specified path or from
 the set of templates that are shipped with Plaster.  Specifying no arguments will
 cause only the built-in Plaster templates to be returned.  Using the -IncludeInstalledModules
 switch will also search the PSModulePath for PowerShell modules that advertise
-Plaster templates that they include.
+Plaster templates that they include. Using the -Name parameter limits the results based on name.
 
 
 The objects returned from this cmdlet will provide details about each individual
@@ -67,6 +67,26 @@ PS C:\> Invoke-Plaster -TemplatePath $templates[0].TemplatePath -DestinationPath
 This will get a list of Plaster templates found recursively under c:\MyPlasterTemplates
 The first template returned is then used to create a new module at the specifed path.
 
+### Example 4
+```
+PS C:\> $template = Get-PlasterTemplate -Name NewPowerShellScriptModule
+
+PS C:\> Invoke-Plaster -TemplatePath $template.TemplatePath -DestinationPath ~\GitHub\NewModule
+```
+
+This will get the built-in Plaster template with the name NewPowerShellScriptModule.
+It will then use that template to create a new module at the specified path.
+
+### Example 5
+```
+PS C:\> $templates = Get-PlasterTemplate -IncludeInstalledModules -Name new*
+
+PS C:\> Invoke-Plaster -TemplatePath $templates[0].TemplatePath -DestinationPath ~\GitHub\NewModule
+```
+
+This will get a list of Plaster templates, both built-in and included with installed
+modules, where the name matches 'new*'.
+It will then use the first template found to create a new module at the specified path.
 ## PARAMETERS
 
 ### -IncludeInstalledModules
@@ -91,7 +111,7 @@ Can also be a path to plasterManifest.xml.
 ```yaml
 Type: String
 Parameter Sets: Path
-Aliases: 
+Aliases:
 
 Required: False
 Position: 0
@@ -105,8 +125,23 @@ Indicates that this cmdlet gets the items in the specified locations and in all 
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: Path, IncludedTemplates
+Aliases:
+
+Required: False
+Position: 1
+Default value: *
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Limits the templates returned to those that match the template name. Wildcard characters are permitted.
+
+```yaml
+Type: String
 Parameter Sets: Path
-Aliases: 
+Aliases:
 
 Required: False
 Position: Named
@@ -129,6 +164,7 @@ found.  The -Recurse switch will cause this path to be searched recursively.
 ### System.Object
 This output object provides the following properties:
 
+- Name: The name of the template
 - Title: The title of the template
 - Author: The author of the template
 - Version: The version of the template

--- a/src/GetPlasterTemplate.ps1
+++ b/src/GetPlasterTemplate.ps1
@@ -11,18 +11,20 @@ function Get-PlasterTemplate {
         $Path,
 
         [Parameter(Position=1,
-        ParameterSetName="Path",
-        HelpMessage="Will return templates that match the name.")]
+                   ParameterSetName="Path",
+                   HelpMessage="Will return templates that match the name.")]
         [Parameter(Position=1,
-        ParameterSetName="IncludedTemplates",
-        HelpMessage="Will return templates that match the name.")]
+                   ParameterSetName="IncludedTemplates",
+                   HelpMessage="Will return templates that match the name.")]
+        [ValidateNotNullOrEmpty()]
         [string]
         $Name = "*",
 
         [Parameter(ParameterSetName="Path",
-        HelpMessage="Will return templates that match the tag.")]
+                   HelpMessage="Will return templates that match the tag.")]
         [Parameter(ParameterSetName="IncludedTemplates",
-        HelpMessage="Will return templates that match the tag.")]
+                   HelpMessage="Will return templates that match the tag.")]
+        [ValidateNotNullOrEmpty()]
         [string]
         $Tag = "*",
 

--- a/test/GetPlasterTemplate.Tests.ps1
+++ b/test/GetPlasterTemplate.Tests.ps1
@@ -13,12 +13,32 @@ Describe 'Get-PlasterTemplate' {
             $templates = Get-PlasterTemplate -Path "$PSScriptRoot/../examples/" -Recurse
             $templates[0].Title | Should -Be "New DSC Resource Script File"
         }
+
+        It "finds templates recursively and by name" {
+            $template = Get-PlasterTemplate -Path "$PSScriptRoot/../examples/" -Recurse -Name 'NewDscResourceScript*'
+            $template.Name | Should -Be "NewDscResourceScriptFile"
+        }
+
+        It "finds templates recursively and by tag" {
+            $template = Get-PlasterTemplate -Path "$PSScriptRoot/../examples/" -Recurse -Tag 'DSC'
+            $template.Name | Should -Be "NewDscResourceScriptFile"
+        }
     }
 
     Context "when searching modules for templates" {
         It "finds built-in templates" {
             $templates = Get-PlasterTemplate
             $templates | Where-Object Title -eq 'New PowerShell Manifest Module' | Should -Not -BeNullOrEmpty
+        }
+
+        It "finds built-in templates by name" {
+            $template = Get-PlasterTemplate -Name 'NewPowerShellScriptModule'
+            $template.Name | Should -Be 'NewPowerShellScriptModule'
+        }
+
+        It "finds built-in templates by tag" {
+            $template = Get-PlasterTemplate -Tag 'Module'
+            $template.Name | Should -Be 'NewPowerShellScriptModule'
         }
 
         It "finds templates included with modules" {


### PR DESCRIPTION
I'm looking at ways to filter the result based on the template name.  I have added an additional parameter called Name to both parameter sets. By default this is set to * and so will return all found templates. If a value is specified then it will only return the the templates where the template name matches. It accepts wildcards as it uses 'like' to do the filtering.

I have put Name as position 1 parameter so as not to impact the position 0 parameter. There could still be some impact for recurse in the path parameter set. Another option would be to make Name position 2 for the path parameter set. Any feedback is appreciated.