### PR TITLE
Bump version to 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Plaster Release History
 
+## 1.1.4 - (Unreleased)
+
 ## 1.1.1 - 2017-10-26
 
 ### Fixed

--- a/src/Plaster.psd1
+++ b/src/Plaster.psd1
@@ -6,7 +6,7 @@
     GUID = 'cfce3c5e-402f-412a-a83a-7b7ee9832ff4'
 
     # Version number of this module.
-    ModuleVersion = '1.1.1'
+    ModuleVersion = '1.1.4'
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a
     # PSData hashtable with additional module metadata used by PowerShell.


### PR DESCRIPTION
Can we bump the module version to 1.1.4 so that we can distinguish between this updated module and the one published in the PowerShell Gallery?