### PR TITLE
Use Write-Host to write dest dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 1.1.4 - (Unreleased)
 
+## Fixed
+
+- Write destination path with Write-Host so it doesn't add extra output when -PassThru specified
+  [#326](https://github.com/PowerShell/Plaster/issues/326).
+
+## Changed
+
+- Updated PSScriptAnalyzerSettings.psd1 template file to sync w/latest in vscode-powershell examples.
+
 ## 1.1.1 - 2017-10-26
 
 ### Fixed

--- a/debugHarness.ps1
+++ b/debugHarness.ps1
@@ -23,7 +23,6 @@ $PlasterParams = @{
     DestinationPath = $OutDir
     ModuleName = 'FooUtils'
     Version = '1.2.0'
-    AddTest = 'Yes'
     Editor = 'VSCode'
     PassThru = $true
 }
@@ -49,4 +48,7 @@ $PlasterParams = @{
 #     PassThru = $true
 # }
 
-Invoke-Plaster @PlasterParams -Force
+$obj = Invoke-Plaster @PlasterParams -Force
+
+"PassThru object is:"
+$obj

--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -1411,7 +1411,7 @@ function Invoke-Plaster {
             }
 
             # Output the DestinationPath
-            $LocalizedData.DestPath_F1 -f $destinationAbsolutePath
+            Write-Host ($LocalizedData.DestPath_F1 -f $destinationAbsolutePath)
 
             # Process content
             foreach ($node in $manifest.plasterManifest.content.ChildNodes) {

--- a/src/Plaster.psd1
+++ b/src/Plaster.psd1
@@ -38,7 +38,7 @@
     CompanyName = 'Microsoft Corporation'
 
     # Copyright statement for this module
-    Copyright = '(c) Microsoft Corporation 2016. All rights reserved.'
+    Copyright = '(c) Microsoft Corporation 2016-2018. All rights reserved.'
 
     # Description of the functionality provided by this module
     Description = 'Plaster scaffolds PowerShell projects and files.'

--- a/test/PlasterManifestValidation.Tests.ps1
+++ b/test/PlasterManifestValidation.Tests.ps1
@@ -234,7 +234,7 @@ Describe 'Module Error Handling Tests' {
 </plasterManifest>
 "@ | Out-File $PlasterManifestPath -Encoding utf8
 
-            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6> $null} | Should Throw
         }
 
         It 'Throws on newModuleManifest destination that is absolute path' {
@@ -260,7 +260,7 @@ Describe 'Module Error Handling Tests' {
 </plasterManifest>
 "@ | Out-File $PlasterManifestPath -Encoding utf8
 
-            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6> $null} | Should Throw
         }
 
         It 'Throws on templateFile destination that is absolute path' {
@@ -283,7 +283,7 @@ Describe 'Module Error Handling Tests' {
 </plasterManifest>
 "@ | Out-File $PlasterManifestPath -Encoding utf8
 
-            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6> $null} | Should Throw
         }
 
         It 'Throws on modify relativePath outside of DestinationPath' {
@@ -312,7 +312,7 @@ Describe 'Module Error Handling Tests' {
 </plasterManifest>
 "@ | Out-File $PlasterManifestPath -Encoding utf8
 
-            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6> $null } | Should Throw
         }
 
         It 'Throws on newModuleManifest relativePath outside of DestinationPath' {
@@ -338,7 +338,7 @@ Describe 'Module Error Handling Tests' {
 </plasterManifest>
 "@ | Out-File $PlasterManifestPath -Encoding utf8
 
-            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6> $null } | Should Throw
         }
 
         It 'Throws on templateFile relativePath outside of DestinationPath' {
@@ -361,7 +361,7 @@ Describe 'Module Error Handling Tests' {
 </plasterManifest>
 "@ | Out-File $PlasterManifestPath -Encoding utf8
 
-            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo} | Should Throw
+            { Invoke-Plaster -TemplatePath $TemplateDir -DestinationPath $OutDir -NoLogo 6> $null } | Should Throw
         }
     }
 }


### PR DESCRIPTION
This avoids an issue where -PassThru was outputting two objects vs one.
We were outputting the dest dir in addition to the custom object.
Now we only output the custom object with -PassThru.
Update debugHarness to remove invalid param.
Update PSD1 copyright to include 2018.

Fixes #326