### PR TITLE
Fixed case-sensitive issue in XML example

### DIFF
--- a/docs/en-US/about_Plaster_CreatingAManifest.help.md
+++ b/docs/en-US/about_Plaster_CreatingAManifest.help.md
@@ -349,7 +349,7 @@ Here is an example of the `newModuleManifest` element:
                    author='$PLASTER_PARAM_FullName'
                    description='$PLASTER_PARAM_ModuleDesc'
                    encoding='UTF8-NoBOM'
-                   powershellVersion='5.1'/>
+                   powerShellVersion='5.1'/>
 ```
 
 ### Content element: RequireModule


### PR DESCRIPTION
The 'newModuleManifest' attribute 'powerShellVersion' was 'powershellVersion'. The lower-case 's' would give an invalid error with Test-PlasterManifest.