### PR TITLE
Only retrieve the latest version manifest per module

### DIFF
--- a/src/GetModuleExtension.ps1
+++ b/src/GetModuleExtension.ps1
@@ -8,12 +8,12 @@ function Get-ModuleExtension {
         $ModuleVersion,
         
         [Switch]
-        $AllVersions
+        $ListAvailable
     )
 
     #Only get the latest version of each module
     $modules = Get-Module -ListAvailable 
-    if (!$AllVersions) {
+    if (!$ListAvailable) {
         $modules = $modules | 
             Group-Object Name | 
             Foreach-Object {

--- a/src/GetModuleExtension.ps1
+++ b/src/GetModuleExtension.ps1
@@ -13,7 +13,7 @@ function Get-ModuleExtension {
 
     #Only get the latest version of each module
     $modules = Get-Module -ListAvailable 
-    if (-not $AllVersions) {
+    if (!$AllVersions) {
         $modules = $modules | 
             Group-Object Name | 
             Foreach-Object {

--- a/src/GetModuleExtension.ps1
+++ b/src/GetModuleExtension.ps1
@@ -6,9 +6,23 @@ function Get-ModuleExtension {
 
         [Version]
         $ModuleVersion
+        
+        [Switch]
+        $AllVersions
     )
 
-    $modules = Get-Module -ListAvailable
+    #Only get the latest version of each module
+    $modules = Get-Module -ListAvailable 
+    if (-not $AllVersions) {
+        $modules = $modules | 
+            Group-Object Name | 
+            Foreach-Object {
+                $_.group | 
+                    Sort-Object Version | 
+                    Select-Object -Last 1
+            }
+    }
+        
     Write-Verbose "`nFound $($modules.Length) installed modules to scan for extensions."
 
     function ParseVersion($versionString) {

--- a/src/GetModuleExtension.ps1
+++ b/src/GetModuleExtension.ps1
@@ -5,7 +5,7 @@ function Get-ModuleExtension {
         $ModuleName,
 
         [Version]
-        $ModuleVersion
+        $ModuleVersion,
         
         [Switch]
         $AllVersions


### PR DESCRIPTION
Current behavior returns plaster manifests for every single version of an installed module. Practice would dictate that you'd generally only want the latest (most stable version), and multiple versions completely pollute the VS Code "New Manifest".

Added an additional trigger to make this behavior optional, and then recommend to roll the operation up to Get-PlasterTemplate to get latest version by default, with a "-ListAvailable" switch to fetch all available manifests if desired.

EDIT: Changed "AllVersions" to "ListAvailable" to better match Get-Module conventions.