### PR TITLE
Enabling ValueFromPipelineByPropertyName for TemplatePath

### DIFF
--- a/src/InvokePlaster.ps1
+++ b/src/InvokePlaster.ps1
@@ -23,7 +23,7 @@ function Invoke-Plaster {
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSShouldProcess', '', Scope='Function', Target='ProcessRequireModule')]
     [CmdletBinding(SupportsShouldProcess=$true)]
     param(
-        [Parameter(Position = 0, Mandatory = $true)]
+        [Parameter(Position = 0, Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $TemplatePath,
@@ -154,7 +154,9 @@ function Invoke-Plaster {
             Write-Host ((" " * (50 - $versionString.Length)) + $versionString)
             Write-Host ("=" * 50)
         }
+    }
 
+    process {
         $boundParameters = $PSBoundParameters
         $constrainedRunspace = $null
         $templateCreatedFiles = @{}


### PR DESCRIPTION
On my first attempt to use Plaster I tried

```PowerShell
Get-PlasterTemplate | select -Skip 1 | Invoke-Plaster -DestinationPath r:\temp
```

And I was prompted for the TemplatePath anyway which was very odd. I reviewed the repo and saw the TemplatePath parameter was not marked with ValueFromPipelineByPropertyName=$true. That cleared up why it did not work but I felt it should so I cloned the repo to start to add it.

That is when I realized all the code is in the **begin** block and pipeline parameters are not passed to **begin** only **process** and **end**. When I added a close brace on line 157 and _process {_ on line 159 everything now works as expected and you can pipe Get-PlasterTemplate into Invoke-Plaster.