### PR TITLE
Documentation on keyboard accelerators in choices.

### DIFF
--- a/docs/en-US/about_Plaster_CreatingAManifest.help.md
+++ b/docs/en-US/about_Plaster_CreatingAManifest.help.md
@@ -116,7 +116,7 @@ Enter the version number for the module (0.1.0):
 ```
 
 ### Parameter Type: Choice
-In interactive mode, the `choice` parameter type asks for a single choice from the available options. This choice type also provides a help option '`?`' used to display the help text:
+In interactive mode, the `choice` parameter type asks for a single choice from the available options. Place the ampersand in front of the character in the `label` that is best suitable as a "keyboard accelerator" for the given choice. This choice type also provides a help option '`?`' used to display the help text:
 
 ```xml
 <parameter name='License' type='choice' default='2' store='text' prompt='Select a license for your module'>
@@ -143,7 +143,7 @@ N - No license specified.
 ```
 
 ### Parameter Type: Multi Choice
-The `multichoice` parameter asks for one or more of the available options (supplied as a comma separated list of choices). This choice type also provides a help option '`?`' used to display the help text:
+The `multichoice` parameter asks for one or more of the available options (supplied as a comma separated list of choices). Place the ampersand in front of the character in the `label` that is best suitable as a "keyboard accelerator" for the given choice. This choice type also provides a help option '`?`' used to display the help text:
 ```xml
 <parameter name='Options' type='multichoice' default='0,1,2' store='text' prompt='Select desired options'>
   <choice label='&amp;Pester test support'


### PR DESCRIPTION
ref #346 

The ampersand in the choice label indicates the character to be used as a keyboard accelerator in the choice. This is a property of ```System.Management.Automation.Host.ChoiceDescription.Label```. 

I added some lines to the documentation to explain this.

https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.host.choicedescription.label?view=powershellsdk-1.1.0#System_Management_Automation_Host_ChoiceDescription_Label